### PR TITLE
[packages] Add iwinfo to list

### DIFF
--- a/packages/minimal.txt
+++ b/packages/minimal.txt
@@ -21,6 +21,7 @@ kmod-ipip
 kmod-iptunnel4
 qos-scripts
 firewall
+iwinfo
 libiwinfo-lua
 
 # GUI


### PR DESCRIPTION
output of iw is verbose. For sitesurvey, channel choosing or
station dump iwinfo is more human friendly to read. see #70 
