### PR TITLE
[feeds] ffwizard-berlin - use HT40 only for channels 36..100

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,4 +1,4 @@
 src-git packages git://github.com/openwrt/packages.git^085e028855d59f2cbcfc079f4ac5dcb1b0b59cad
 src-git luci git://git.openwrt.org/project/luci.git^02deb439472a9732240f2f3ef34e70379012b334
 src-git routing git://github.com/openwrt-routing/packages.git^c74c874d7624e6e438d9f6ab8c5d4fe9aa6e67c9
-src-git packages_berlin git://github.com/freifunk-berlin/packages_berlin.git^dc226f2cc0fc41b40b89f0ea69d7118907d5d8e4
+src-git packages_berlin git://github.com/freifunk-berlin/packages_berlin.git^7ecb05dc27c0d3a8683b2aa28a0765da497b341c


### PR DESCRIPTION
As proposed in #87 HTmode for 2.4 should only be 20
