### PR TITLE
[patches] remove 006-target-imagebuilder-remove-initramfs-dep.patch

### DIFF
--- a/patches/006-target-imagebuilder-remove-initramfs-dep.patch
+++ b/patches/006-target-imagebuilder-remove-initramfs-dep.patch
@@ -1,9 +1,0 @@
---- a/target/imagebuilder/Config.in
-+++ b/target/imagebuilder/Config.in
-@@ -1,6 +1,5 @@
- config IB
- 	bool "Build the OpenWrt Image Builder"
--	depends on !TARGET_ROOTFS_INITRAMFS
- 	depends on !PROFILE_KCONFIG
- 	depends on !EXTERNAL_TOOLCHAIN
- 	help

--- a/patches/series
+++ b/patches/series
@@ -1,7 +1,6 @@
 001-package-mac80211-regdb.patch
 002-target-atheros-whr-hp-ag108-sysupgrade.patch
 004-package-openssl-broken.patch
-006-target-imagebuilder-remove-initramfs-dep.patch
 007-routing-olsrd-ipv6-bind-only.patch
 008-luci-freifunk-gwcheck.patch
 009-luci-freifunk-map.patch


### PR DESCRIPTION
This patch was for ar71xx-nand targets but has been fixed upstream.
