### PR TITLE
[patches] pr - add rule for tunl0 to olsr-tunnel

### DIFF
--- a/patches/011-luci-freifunk-policyrouting-berlin.patch
+++ b/patches/011-luci-freifunk-policyrouting-berlin.patch
@@ -236,7 +236,7 @@ Index: openwrt/feeds/luci/contrib/package/freifunk-policyrouting/files/etc/init.
  
  		add_lookup_rule olsr olsr 1000
  		add_lookup_rule localnets localnets 2000
-@@ -132,6 +170,20 @@ start() {
+@@ -132,6 +170,26 @@ start() {
  		if [ "$fallback" = 1 ]; then
  			add_lookup_rule olsr-default olsr-default 100000
  		fi
@@ -248,7 +248,13 @@ Index: openwrt/feeds/luci/contrib/package/freifunk-policyrouting/files/etc/init.
 +			fi
 +			networks="$networks $network_zone"
 +		done
++
++		sgw="$(uci -q get olsrd.@olsrd[0].SmartGateway)"
 +		for n in $networks; do
++			# only add route for tunnel if smart gateway is enabled
++			if [ "$sgw" = "yes" ]; then
++				add_lookup_rule olsr-tunnel olsr-tunnel 19999 $n
++			fi
 +			add_lookup_rule olsr-default olsr-default 20000 $n
 +			if [ "$strict" != 0 ]; then
 +				add_action_rule olsr-default_unreachable unreachable 20001 $n
@@ -257,7 +263,7 @@ Index: openwrt/feeds/luci/contrib/package/freifunk-policyrouting/files/etc/init.
  	fi
  	uci commit network
  	if [ ! "$1" = "noservicerestart" ]; then
-@@ -142,20 +194,28 @@ start() {
+@@ -142,20 +200,33 @@ start() {
  stop() {
  	logger -s -t policyrouting "Stopping policy routing"
  	olsrd_rmtables
@@ -276,7 +282,12 @@ Index: openwrt/feeds/luci/contrib/package/freifunk-policyrouting/files/etc/init.
 +		fi
 +		networks="$networks $network_zone"
 +	done
++
++	sgw=$(uci -q get olsrd.@olsrd[0].SmartGateway)
 +	for n in $networks; do
++		if [ "$sgw" = "yes" ]; then
++			del_rule olsr-tunnel $n
++		fi
 +		del_rule olsr-default $n
 +		if [ "$strict" != 0 ]; then
 +			del_rule olsr-default_unreachable $n


### PR DESCRIPTION
The default route of VPN03 will be added to olsr-tunnel table. tunl0 is the
interface for incoming SmartGateway tunnels. As there was no rule for tunl0 to
look into olsr-tunnel routing table all SmartGateway clients had no uplink
access. This changeset adds an additional ip rule for tunl0 for the olsr-tunnel
table like "19999:  from all iif tunl0 lookup olsr-tunnel".

Normally this should not be necessary because the hotplug.d policyrouting script
should take care of this but netifd does not trigger an event for tunl0 (tunnel
interfaces) and therefor this script will never be called.
