### PR TITLE
[packages] Add unreachable rules for tunl0

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,4 +1,4 @@
 src-git packages git://github.com/openwrt/packages.git^085e028855d59f2cbcfc079f4ac5dcb1b0b59cad
 src-git luci git://github.com/openwrt/luci.git^ecb0c2f11b861e5035b0397d2396ee4b5e9b3c3e
 src-git routing git://github.com/openwrt-routing/packages.git^3b6e617ac548b8b71c9c8eac179875ea1875814a
-src-git packages_berlin git://github.com/freifunk-berlin/packages_berlin.git^484c7410269892124e42263217b33e077c7d2cba
+src-git packages_berlin git://github.com/freifunk-berlin/packages_berlin.git^ff4a8a689309fb1136101bfc54921aa95305fe97


### PR DESCRIPTION
Always set tunl0 as network interface for freifunk firewall zone (fixes #133)
This ensures that freifunk-policyrouting adds unreachable rules for tunl0
otherwise traffic may leak if a SmartGateway client creates a tunnel.
After firstboot ip ruleset looks now like the following:

$ ip rule
  0:      from all lookup local
  1000:   from all lookup olsr
  2000:   from all lookup localnets
  19999:  from all iif tunl0 lookup olsr-tunnel
  20000:  from all iif tunl0 lookup olsr-default
  20001:  from all iif tunl0 unreachable
  32766:  from all lookup main
  32767:  from all lookup default
