### PR TITLE
[patches] firstboot - fix auth parameters

### DIFF
--- a/patches/014-ffwizard-redirect-on-firstboot.patch
+++ b/patches/014-ffwizard-redirect-on-firstboot.patch
@@ -20,12 +20,12 @@ Index: openwrt/feeds/luci/modules/freifunk/luasrc/view/freifunk/index.htm
 +local ipkg = require "luci.model.ipkg"
 +
 +-- only redirect if assistent is installed and no root password is set
-+if ipkg.installed("luci-app-ffwizard-berlin") == True and http.getenv("PATH_INFO") == nil then
++if (ipkg.installed("luci-app-ffwizard-berlin") == True and http.getenv("PATH_INFO") == nil) then
 +	local runbefore = uci.get("ffwizard","settings","runbefore")
 +	if not runbefore then
 +		local url = luci.dispatcher.build_url("admin/freifunk/assistent")
 +		if sys.user.checkpasswd("root", "") then
-+			url = url .. "?username=root&password="
++			url = url .. "?luci_username=root&luci_password="
 +		end
 +		http.redirect(url)
 +	end


### PR DESCRIPTION
With ff65318ba52109f4ca7eb83a639ecddda2a8b3fc luci changed name of auth
parameters to "attempt to work around Firefox autocomplete bugs".
They were changed from username and password to luci_username and
luci_password.

Fixes #136.
