### PR TITLE
add tmp files from quilt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*.swp
 .stamp*
+patches/*~
 bin
 openwrt
 firmwares


### PR DESCRIPTION
`quilt edit` generates temporary files with a tilde suffix (not for all editors
but for vim for example). We do not want them in our repository.
