### PR TITLE
[patches] add two ipv6 nameservers

### DIFF
--- a/patches/015-profile_berlin.patch
+++ b/patches/015-profile_berlin.patch
@@ -43,8 +43,7 @@ Index: openwrt/feeds/luci/contrib/package/community-profiles/files/etc/config/pr
  
  config 'defaults' 'interface'
 -	option 'netmask' '255.0.0.0'
-+	option 'netmask' '255.255.255.255'
- 	option 'dns' '85.214.20.141 213.73.91.35 194.150.168.168'
+-	option 'dns' '85.214.20.141 213.73.91.35 194.150.168.168'
 -
 -config 'defaults' 'olsr_interface'
 -	option 'Ip4Broadcast' '255.255.255.255'
@@ -66,3 +65,5 @@ Index: openwrt/feeds/luci/contrib/package/community-profiles/files/etc/config/pr
 -	option 'LinkQualityAlgorithm' 'etx_ff'
 -	option 'RtTableDefaultOlsrPriority' '20000'
 -	option 'RtTableTunnelPriority' '100000'
++	option 'netmask' '255.255.255.255'
++	option 'dns' '85.214.20.141 213.73.91.35 194.150.168.168 2001:4ce8::53 2001:910:800::12'


### PR DESCRIPTION
On the second hackathon we agreed to add two ipv6 nameservers:
- 2001:4ce8::53 (as250)
- 2001:910:800::12 (french data network - http://www.fdn.fr/)

Closes #15.
