### PR TITLE
[patches] backport support for ubnt loco xw

### DIFF
--- a/patches/001-target-ubnt-xw-loco.patch
+++ b/patches/001-target-ubnt-xw-loco.patch
@@ -1,0 +1,184 @@
+Index: openwrt/target/linux/ar71xx/patches-3.10/616-MIPS-ath79-ubnt-xw.patch
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/patches-3.10/616-MIPS-ath79-ubnt-xw.patch
++++ openwrt/target/linux/ar71xx/patches-3.10/616-MIPS-ath79-ubnt-xw.patch
+@@ -1,6 +1,6 @@
+ --- a/arch/mips/ath79/mach-ubnt-xm.c
+ +++ b/arch/mips/ath79/mach-ubnt-xm.c
+-@@ -332,3 +332,60 @@ static void __init ubnt_uap_pro_setup(vo
++@@ -332,3 +332,78 @@ static void __init ubnt_uap_pro_setup(vo
+  MIPS_MACHINE(ATH79_MACH_UBNT_UAP_PRO, "UAP-PRO", "Ubiquiti UniFi AP Pro",
+  	     ubnt_uap_pro_setup);
+  
+@@ -29,7 +29,7 @@
+ +	},
+ +};
+ +
+-+static void __init ubnt_nano_m_xw_setup(void)
+++static void __init ubnt_xw_init(void)
+ +{
+ +	u8 *eeprom = (u8 *) KSEG1ADDR(0x1fff0000);
+ +
+@@ -44,26 +44,48 @@
+ +	ath79_register_wmac(eeprom + UAP_PRO_WMAC_CALDATA_OFFSET, NULL);
+ +	ap91_pci_init(eeprom + UAP_PRO_PCI_CALDATA_OFFSET, NULL);
+ +
+-+	ath79_register_mdio(0, ~(BIT(0) | BIT(1) | BIT(5)));
+ +
+ +	ath79_setup_ar934x_eth_cfg(AR934X_ETH_CFG_MII_GMAC0 | AR934X_ETH_CFG_MII_GMAC0_SLAVE);
+ +	ath79_init_mac(ath79_eth0_data.mac_addr,
+ +		       eeprom + UAP_PRO_MAC0_OFFSET, 0);
+ +
+-+	/* GMAC0 is connected to an AR8326 switch */
+ +	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
+++	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
+++}
+++
+++static void __init ubnt_nano_m_xw_setup(void)
+++{
+++	ubnt_xw_init();
+++
+++	/* GMAC0 is connected to an AR8326 switch */
+++	ath79_register_mdio(0, ~(BIT(0) | BIT(1) | BIT(5)));
+ +	ath79_eth0_data.phy_mask = (BIT(0) | BIT(1) | BIT(5));
+ +	ath79_eth0_data.speed = SPEED_100;
+ +	ath79_eth0_data.duplex = DUPLEX_FULL;
+-+	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
+++	ath79_register_eth(0);
+++}
+++
+++static void __init ubnt_loco_m_xw_setup(void)
+++{
+++	ubnt_xw_init();
+++
+++	ath79_register_mdio(0, ~BIT(1));
+++	ath79_eth0_data.phy_mask = BIT(1);
+ +	ath79_register_eth(0);
+ +}
+ +
+ +MIPS_MACHINE(ATH79_MACH_UBNT_NANO_M_XW, "UBNT-NM-XW", "Ubiquiti Nanostation M XW",
+ +	     ubnt_nano_m_xw_setup);
+++
+++MIPS_MACHINE(ATH79_MACH_UBNT_LOCO_M_XW, "UBNT-LOCO-XW", "Ubiquiti Loco M XW",
+++	     ubnt_loco_m_xw_setup);
+ --- a/arch/mips/ath79/machtypes.h
+ +++ b/arch/mips/ath79/machtypes.h
+-@@ -124,6 +124,7 @@ enum ath79_mach_type {
++@@ -121,9 +121,11 @@ enum ath79_mach_type {
++ 	ATH79_MACH_TL_WR941ND,		/* TP-LINK TL-WR941ND */
++ 	ATH79_MACH_UBNT_AIRROUTER,	/* Ubiquiti AirRouter */
++ 	ATH79_MACH_UBNT_BULLET_M,	/* Ubiquiti Bullet M */
+++	ATH79_MACH_UBNT_LOCO_M_XW, 	/* Ubiquiti Loco M XW */
+  	ATH79_MACH_UBNT_LSSR71,		/* Ubiquiti LS-SR71 */
+  	ATH79_MACH_UBNT_LSX,		/* Ubiquiti LSX */
+  	ATH79_MACH_UBNT_NANO_M, 	/* Ubiquiti NanoStation M */
+Index: openwrt/target/linux/ar71xx/base-files/etc/diag.sh
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/base-files/etc/diag.sh
++++ openwrt/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -34,7 +34,7 @@ get_status_led() {
+ 	aw-nr580)
+ 		status_led="aw-nr580:green:ready"
+ 		;;
+-	bullet-m | rocket-m | nano-m | nanostation-m | nanostation-m-xw)
++	bullet-m | rocket-m | nano-m | nanostation-m | nanostation-m-xw | loco-m-xw)
+ 		status_led="ubnt:green:link4"
+ 		;;
+ 	bxu2000n-2-a1)
+Index: openwrt/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
++++ openwrt/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+@@ -38,7 +38,8 @@ ap113)
+ bullet-m | \
+ nanostation-m | \
+ rocket-m | \
+-nanostation-m-xw)
++nanostation-m-xw | \
++loco-m-xw)
+ 	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:red:link1" "wlan0" "1" "100" "0" "13"
+ 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "ubnt:orange:link2" "wlan0" "26" "100" "-25" "13"
+ 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ubnt:green:link3" "wlan0" "51" "100" "-50" "13"
+Index: openwrt/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
++++ openwrt/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
+@@ -286,6 +286,7 @@ bullet-m |\
+ cap4200ag |\
+ eap300v2 |\
+ eap7660d |\
++loco-m-xw |\
+ mr600 |\
+ mr600v2 |\
+ rb-411 |\
+Index: openwrt/target/linux/ar71xx/base-files/lib/ar71xx.sh
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ openwrt/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -352,6 +352,9 @@ ar71xx_board_detect() {
+ 	*"Bullet M")
+ 		name="bullet-m"
+ 		;;
++	*"Loco M XW")
++		name="loco-m-xw"
++		;;
+ 	*"Nanostation M")
+ 		name="nanostation-m"
+ 		;;
+Index: openwrt/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ openwrt/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -190,6 +190,7 @@ platform_check_image() {
+ 	airgateway | \
+ 	airrouter | \
+ 	bullet-m | \
++	loco-m-xw | \
+ 	nanostation-m | \
+ 	rocket-m | \
+ 	nanostation-m-xw | \
+Index: openwrt/target/linux/ar71xx/image/Makefile
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/image/Makefile
++++ openwrt/target/linux/ar71xx/image/Makefile
+@@ -1246,6 +1246,7 @@ $(eval $(call SingleProfile,UBNTXM,64kra
+ $(eval $(call SingleProfile,UBNTXM,64kraw,UBNTUNIFI,ubnt-unifi,UBNT-UF,ttyS0,115200,XM,BZ,ar7240))
+ $(eval $(call SingleProfile,UBNTXM,64kraw,UBNTUNIFIOUTDOOR,ubnt-unifi-outdoor,UBNT-U20,ttyS0,115200,XM,BZ,ar7240))
+ $(eval $(call SingleProfile,UBNTXM,64kraw,UBNTNANOMXW,ubnt-nano-m-xw,UBNT-NM-XW,ttyS0,115200,XM,XW,ar934x))
++$(eval $(call SingleProfile,UBNTXM,64kraw,UBNTLOCOXW,ubnt-loco-m-xw,UBNT-LOCO-XW,ttyS0,115200,XM,XW,ar934x))
+ $(eval $(call SingleProfile,UBNTXM,64kraw,UBNTAIRGW,ubnt-air-gateway,UBNT-AGW,ttyATH0,115200,XM,AirGW,ar933x))
+ 
+ $(eval $(call SingleProfile,WHRHPG300N,64kraw,WHRG301N,whr-g301n,WHR-G301N,ttyS0,115200,$$(whrhpg300n_mtdlayout),WHR-G301N))
+@@ -1291,7 +1292,7 @@ $(eval $(call MultiProfile,TLWR941,TLWR9
+ $(eval $(call MultiProfile,TLWR1043,TLWR1043V1 TLWR1043V2))
+ $(eval $(call MultiProfile,TLWDR4300,TLWDR3500V1 TLWDR3600V1 TLWDR4300V1 TLWDR4300V1IL TLWDR4310V1 MW4530RV1))
+ $(eval $(call MultiProfile,TUBE2H,TUBE2H8M TUBE2H16M))
+-$(eval $(call MultiProfile,UBNT,UBNTAIRROUTER UBNTRS UBNTRSPRO UBNTLSSR71 UBNTBULLETM UBNTROCKETM UBNTNANOM UBNTNANOMXW UBNTUNIFI UBNTUNIFIOUTDOOR UAPPRO UBNTAIRGW))
++$(eval $(call MultiProfile,UBNT,UBNTAIRROUTER UBNTRS UBNTRSPRO UBNTLSSR71 UBNTBULLETM UBNTROCKETM UBNTNANOM UBNTNANOMXW UBNTLOCOXW UBNTUNIFI UBNTUNIFIOUTDOOR UAPPRO UBNTAIRGW))
+ $(eval $(call MultiProfile,WNDR3700,WNDR3700V1 WNDR3700V2 WNDR3800 WNDR3800CH WNDRMAC WNDRMACV2))
+ $(eval $(call MultiProfile,WNR612V2,REALWNR612V2 N150R))
+ $(eval $(call MultiProfile,WP543,WP543_2M WP543_4M WP543_8M WP543_16M))
+Index: openwrt/target/linux/ar71xx/patches-3.10/722-MIPS-ath79-add-airGateway-support.patch
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/patches-3.10/722-MIPS-ath79-add-airGateway-support.patch
++++ openwrt/target/linux/ar71xx/patches-3.10/722-MIPS-ath79-add-airGateway-support.patch
+@@ -12,10 +12,10 @@
+  #include "dev-ap9x-pci.h"
+  #include "dev-eth.h"
+  #include "dev-gpio-buttons.h"
+-@@ -389,3 +391,65 @@ static void __init ubnt_nano_m_xw_setup(
++@@ -406,3 +408,65 @@ MIPS_MACHINE(ATH79_MACH_UBNT_NANO_M_XW,
+  
+- MIPS_MACHINE(ATH79_MACH_UBNT_NANO_M_XW, "UBNT-NM-XW", "Ubiquiti Nanostation M XW",
+- 	     ubnt_nano_m_xw_setup);
++ MIPS_MACHINE(ATH79_MACH_UBNT_LOCO_M_XW, "UBNT-LOCO-XW", "Ubiquiti Loco M XW",
++ 	     ubnt_loco_m_xw_setup);
+ +
+ +static struct gpio_led ubnt_airgateway_gpio_leds[] __initdata = {
+ +	{
+@@ -87,4 +87,4 @@
+ +	ATH79_MACH_UBNT_AIRGW,		/* Ubiquiti AirGateway */
+  	ATH79_MACH_UBNT_AIRROUTER,	/* Ubiquiti AirRouter */
+  	ATH79_MACH_UBNT_BULLET_M,	/* Ubiquiti Bullet M */
+- 	ATH79_MACH_UBNT_LSSR71,		/* Ubiquiti LS-SR71 */
++ 	ATH79_MACH_UBNT_LOCO_M_XW, 	/* Ubiquiti Loco M XW */

--- a/patches/series
+++ b/patches/series
@@ -1,3 +1,4 @@
+001-target-ubnt-xw-loco.patch
 002-banner-info.patch
 004-routing-olsrd-dyn_gw-ping_cmd.patch
 006-target-imagebuilder-remove-initramfs-dep.patch


### PR DESCRIPTION
This backports support for Ubiquit Nanostation XW from Chaos Calmer. The
following commits have been backported:
- http://git.openwrt.org/?p=openwrt.git;a=patch;h=e92748a8b17f386a45207316e3af7c686ed887ee
- http://git.openwrt.org/?p=openwrt.git;a=patch;h=3d217029ea89de6520e01a471b6dc31924f17327

Fixes #26.
