### PR TITLE
remove 4MB constraint from mikrotik profile

### DIFF
--- a/profiles/ar71xx_mikrotik.profiles
+++ b/profiles/ar71xx_mikrotik.profiles
@@ -1,1 +1,1 @@
-DefaultNoWifi:4MB
+DefaultNoWifi


### PR DESCRIPTION
Fixes #186.

Buildbot: http://buildbot.berlin.freifunk.net/builders/ar71xx_mikrotik/builds/361
Buildbot images should end up here: http://buildbot.berlin.freifunk.net/buildbot/unstable/ar71xx_mikrotik/361

@faust2k: can you test once the image is available? I don't have a mikrotik board... :smile: 
