### PR TITLE
[feeds] update feeds to include vpn03-firewall fix

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,4 +1,4 @@
 src-git packages git://github.com/openwrt/packages.git^e9189f2efd890ced5309aafd6599370b39154432
 src-git luci git://github.com/openwrt/luci.git^ecb0c2f11b861e5035b0397d2396ee4b5e9b3c3e
 src-git routing git://github.com/openwrt-routing/packages.git^3b6e617ac548b8b71c9c8eac179875ea1875814a
-src-git packages_berlin git://github.com/freifunk-berlin/firmware-packages.git^f08a5ec4d93d1d02095e3841fbafd3bdb758fb78
+src-git packages_berlin git://github.com/freifunk-berlin/firmware-packages.git^b0c7469e2b0e7fc982c2257e77e44fac9e95ae9c


### PR DESCRIPTION
Update feed of freifunk-berlin/firmware-packages with fixes of
vpn03-related firewall rules. This should also fix a malfunctioning
olsr, see error messages in #171 and #192.