### PR TITLE
[packages] add luci-app-firewall

### DIFF
--- a/packages/vpn.txt
+++ b/packages/vpn.txt
@@ -35,6 +35,7 @@ px5g
 luci-app-ffwizard-berlin
 luci-mod-freifunk
 luci-app-olsr
+luci-app-firewall
 luci-app-olsr-services
 luci-app-owm
 luci-app-owm-ant


### PR DESCRIPTION
At the moment users can't change firewall settings without using a shell. This
adds the `luci-app-firewall` package to empower people without shell knowledge to
change firewall settings on their own.