### PR TITLE
[Makefile]: remove build_dir/target-* when cleaning up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ openwrt-clean: stamp-clean-openwrt-cleaned .stamp-openwrt-cleaned
 	cd $(OPENWRT_DIR); \
 	  ./scripts/feeds clean && \
 	  git clean -dff && git fetch && git reset --hard HEAD && \
-	  rm -rf bin .config feeds.conf
+	  rm -rf bin .config feeds.conf build_dir/target-*
 	touch $@
 
 # update openwrt and checkout specified commit


### PR DESCRIPTION
The build isn't cleaned up when we add patches to target/linux/ar71xx/patches