### PR TITLE
Bugfix/remove migration from backbone

### DIFF
--- a/packages/backbone.txt
+++ b/packages/backbone.txt
@@ -5,7 +5,6 @@
 # Defaults
 freifunk-berlin-dhcp-defaults
 freifunk-berlin-freifunk-defaults
-freifunk-berlin-migration
 freifunk-berlin-network-defaults
 freifunk-berlin-olsrd-defaults
 freifunk-berlin-statistics-defaults


### PR DESCRIPTION
Backbone installations are configured manually. If we run our migration script
here it will break the config. Therefor remove the migration script from package
list.