### PR TITLE
configs/ar71xx: build ath9k-htc module

### DIFF
--- a/configs/ar71xx.config
+++ b/configs/ar71xx.config
@@ -59,6 +59,7 @@ CONFIG_PACKAGE_iptables-mod-conntrack-extra=m
 CONFIG_PACKAGE_iptables-mod-filter=m
 CONFIG_PACKAGE_iptables-mod-ipopt=m
 CONFIG_PACKAGE_iwinfo=m
+CONFIG_PACKAGE_kmod-ath9k-htc=m
 CONFIG_PACKAGE_kmod-batman-adv=m
 CONFIG_PACKAGE_kmod-crypto-crc32c=m
 CONFIG_PACKAGE_kmod-crypto-hash=m

--- a/configs/ar71xx_mikrotik.config
+++ b/configs/ar71xx_mikrotik.config
@@ -59,6 +59,7 @@ CONFIG_PACKAGE_iptables-mod-conntrack-extra=m
 CONFIG_PACKAGE_iptables-mod-filter=m
 CONFIG_PACKAGE_iptables-mod-ipopt=m
 CONFIG_PACKAGE_iwinfo=m
+CONFIG_PACKAGE_kmod-ath9k-htc=m
 CONFIG_PACKAGE_kmod-batman-adv=m
 CONFIG_PACKAGE_kmod-crypto-crc32c=m
 CONFIG_PACKAGE_kmod-crypto-hash=m

--- a/configs/mpc85xx.config
+++ b/configs/mpc85xx.config
@@ -59,6 +59,7 @@ CONFIG_PACKAGE_iptables-mod-conntrack-extra=m
 CONFIG_PACKAGE_iptables-mod-filter=m
 CONFIG_PACKAGE_iptables-mod-ipopt=m
 CONFIG_PACKAGE_iwinfo=m
+CONFIG_PACKAGE_kmod-ath9k-htc=m
 CONFIG_PACKAGE_kmod-batman-adv=m
 CONFIG_PACKAGE_kmod-crypto-crc32c=m
 CONFIG_PACKAGE_kmod-crypto-hash=m

--- a/configs/x86.config
+++ b/configs/x86.config
@@ -68,6 +68,7 @@ CONFIG_PACKAGE_kmod-ath10k=m
 CONFIG_PACKAGE_kmod-ath5k=m
 CONFIG_PACKAGE_kmod-ath9k=m
 CONFIG_PACKAGE_kmod-ath9k-common=m
+CONFIG_PACKAGE_kmod-ath9k-htc=m
 CONFIG_PACKAGE_kmod-batman-adv=m
 CONFIG_PACKAGE_kmod-cfg80211=m
 CONFIG_PACKAGE_kmod-crypto-aes=m


### PR DESCRIPTION
Requested in http://lists.berlin.freifunk.net/pipermail/berlin/2015-April/027818.html . Tested with a 4300. Works.