### PR TITLE
[patches] LuCI bootstrap theme CSS improvements for input fields

### DIFF
--- a/patches/017-luci-bootstrap-input-css.patch
+++ b/patches/017-luci-bootstrap-input-css.patch
@@ -1,0 +1,17 @@
+Index: firmware/openwrt/feeds/luci/themes/bootstrap/htdocs/luci-static/bootstrap/cascade.css
+===================================================================
+--- openwrt.orig/feeds/luci/themes/bootstrap/htdocs/luci-static/bootstrap/cascade.css	2015-04-09 01:44:12.000000000 +0200
++++ openwrt/feeds/luci/themes/bootstrap/htdocs/luci-static/bootstrap/cascade.css	2015-04-25 12:54:35.000000000 +0200
+@@ -489,6 +489,12 @@
+ 
+ select {
+ 	padding: initial;
++	color: #303030;
++	background-color: #f8f8f8; 
++}
++
++input {   
++	color: #303030;
+ }
+ 
+ input[type=checkbox], input[type=radio] {

--- a/patches/series
+++ b/patches/series
@@ -6,3 +6,4 @@
 013-delete_non_existing_profiles.patch
 014-ffwizard-redirect-on-firstboot.patch
 015-profile_berlin.patch
+017-luci-bootstrap-input-css.patch


### PR DESCRIPTION
Input fields and dropdown boxes used gray text color/background
which is typically used to indicate inactive fields.

This fixes https://github.com/freifunk-berlin/firmware/issues/213