### PR TITLE
[kernel] backported OpenWrt r43974 kernel patch 736 (MIPS-ath79-chained-irq-disable)

### DIFF
--- a/patches/018-backport-openwrt-r43974-736-MIPS-ath79-chained-irq-disable.patch
+++ b/patches/018-backport-openwrt-r43974-736-MIPS-ath79-chained-irq-disable.patch
@@ -1,0 +1,80 @@
+Index: openwrt/target/linux/ar71xx/patches-3.10/736-MIPS-ath79-fix-chained-irq-disable.patch
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ openwrt/target/linux/ar71xx/patches-3.10/736-MIPS-ath79-fix-chained-irq-disable.patch	2015-02-18 00:15:01.979480523 +0100
+@@ -0,0 +1,75 @@
++--- a/arch/mips/ath79/irq.c
+++++ b/arch/mips/ath79/irq.c
++@@ -26,6 +26,8 @@
++ 
++ static void (*ath79_ip2_handler)(void);
++ static void (*ath79_ip3_handler)(void);
+++static struct irq_chip ip2_chip;
+++static struct irq_chip ip3_chip;
++ 
++ static void ath79_misc_irq_handler(unsigned int irq, struct irq_desc *desc)
++ {
++@@ -148,8 +150,7 @@ static void ar934x_ip2_irq_init(void)
++ 
++ 	for (i = ATH79_IP2_IRQ_BASE;
++ 	     i < ATH79_IP2_IRQ_BASE + ATH79_IP2_IRQ_COUNT; i++)
++-		irq_set_chip_and_handler(i, &dummy_irq_chip,
++-					 handle_level_irq);
+++		irq_set_chip_and_handler(i, &ip2_chip, handle_level_irq);
++ 
++ 	irq_set_chained_handler(ATH79_CPU_IRQ(2), ar934x_ip2_irq_dispatch);
++ }
++@@ -223,15 +222,13 @@ static void qca955x_irq_init(void)
++ 
++ 	for (i = ATH79_IP2_IRQ_BASE;
++ 	     i < ATH79_IP2_IRQ_BASE + ATH79_IP2_IRQ_COUNT; i++)
++-		irq_set_chip_and_handler(i, &dummy_irq_chip,
++-					 handle_level_irq);
+++		irq_set_chip_and_handler(i, &ip2_chip, handle_level_irq);
++ 
++ 	irq_set_chained_handler(ATH79_CPU_IRQ(2), qca955x_ip2_irq_dispatch);
++ 
++ 	for (i = ATH79_IP3_IRQ_BASE;
++ 	     i < ATH79_IP3_IRQ_BASE + ATH79_IP3_IRQ_COUNT; i++)
++-		irq_set_chip_and_handler(i, &dummy_irq_chip,
++-					 handle_level_irq);
+++		irq_set_chip_and_handler(i, &ip3_chip, handle_level_irq);
++ 
++ 	irq_set_chained_handler(ATH79_CPU_IRQ(3), qca955x_ip3_irq_dispatch);
++ 
++@@ -337,8 +335,35 @@ static void ar934x_ip3_handler(void)
++ 	do_IRQ(ATH79_CPU_IRQ(3));
++ }
++ 
+++static void ath79_ip2_disable(struct irq_data *data)
+++{
+++	disable_irq(ATH79_CPU_IRQ(2));
+++}
+++
+++static void ath79_ip2_enable(struct irq_data *data)
+++{
+++	enable_irq(ATH79_CPU_IRQ(2));
+++}
+++
+++static void ath79_ip3_disable(struct irq_data *data)
+++{
+++	disable_irq(ATH79_CPU_IRQ(3));
+++}
+++
+++static void ath79_ip3_enable(struct irq_data *data)
+++{
+++	enable_irq(ATH79_CPU_IRQ(3));
+++}
+++
++ void __init arch_init_irq(void)
++ {
+++	ip2_chip = dummy_irq_chip;
+++	ip3_chip = dummy_irq_chip;
+++	ip2_chip.irq_disable = ath79_ip2_disable;
+++	ip2_chip.irq_enable = ath79_ip2_enable;
+++	ip3_chip.irq_disable = ath79_ip3_disable;
+++	ip3_chip.irq_enable = ath79_ip3_enable;
+++
++ 	if (soc_is_ar71xx()) {
++ 		ath79_ip2_handler = ar71xx_ip2_handler;
++ 		ath79_ip3_handler = ar71xx_ip3_handler;

--- a/patches/series
+++ b/patches/series
@@ -6,3 +6,4 @@
 013-delete_non_existing_profiles.patch
 014-ffwizard-redirect-on-firstboot.patch
 015-profile_berlin.patch
+018-backport-openwrt-r43974-736-MIPS-ath79-chained-irq-disable.patch


### PR DESCRIPTION
See https://github.com/freifunk-berlin/firmware/issues/216