### PR TITLE
config.mk: update barrierbreaker rev

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -3,5 +3,5 @@ SHELL:=$(shell which bash)
 TARGET=ar71xx
 PACKAGES_LIST_DEFAULT=default backbone
 OPENWRT_SRC=git://git.openwrt.org/14.07/openwrt.git
-OPENWRT_COMMIT=7d01d821b05b26304ab8f8fc148e690cb5ffd8b3
+OPENWRT_COMMIT=229d60fdb45c34902d402938e231c006f7c73931
 MAKE_ARGS=


### PR DESCRIPTION
Changelog:
229d60f BB: openssl: update to v1.0.2a (14 CVEs)
64ae631 kernel: remove the netfilter optimization that skips the filter table, it has caused too many issues
8737792 ath9k: fix a beacon enable handling bug
12c281e ar71xx: Fix LED polarity for the TP-LINK TL-MR13U.
26093e7 Backport: ar71xx: Fix board detection for the TP-LINK TL-MR13U.
878af31 BB: ubox: fix segmentation fault in insmod
11fa76d BB: fstools: fix build with enabled ubifs extroot support
8d49c6d BB: fstools: cumulative backport
dfcbb35 BB: ubox: kmodloader: support loading kmods from multiple directories
e0b8c83 samba36: update to 3.6.25, fixes remote code execution bug (CVE-2015-0240)
edefd1a BB: build: improve feed handling for opkg.conf
4ae7fc3 BB:ramips:Kingston MLW221 cleanup
e602c6d openssl: fix upstream regression for non-ec builds
a31e28a openssl: bump to 1.0.2