### PR TITLE
config.mk: update openwrt revision

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -3,5 +3,5 @@ SHELL:=$(shell which bash)
 TARGET=ar71xx
 PACKAGES_LIST_DEFAULT=default backbone
 OPENWRT_SRC=git://git.openwrt.org/14.07/openwrt.git
-OPENWRT_COMMIT=229d60fdb45c34902d402938e231c006f7c73931
+OPENWRT_COMMIT=10b1d597b97bf9038d18eb8c7c5a8d127c72e5da
 MAKE_ARGS=


### PR DESCRIPTION
Includes security updates for e.g. openssl. This should fix the broken openssl
in the current master too.