### PR TITLE
Revert: "[Makefile] describe version" (breaks filenames and migration)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ include config.mk
 MAINTARGET=$(word 1, $(subst _, ,$(TARGET)))
 SUBTARGET=$(word 2, $(subst _, ,$(TARGET)))
 
-VERSION=$(shell git describe --tags --long --dirty --match 'v[0-9].[0-9].[0-9]*')
-REVISION=$(shell git log -1 --format=format:%h)
-
 # set dir and file names
 FW_DIR=$(shell pwd)
 OPENWRT_DIR=$(FW_DIR)/openwrt
@@ -73,14 +70,12 @@ patch: stamp-clean-patched .stamp-patched
 # openwrt config
 $(OPENWRT_DIR)/.config: .stamp-feeds-updated $(TARGET_CONFIG)
 	cp $(TARGET_CONFIG) $(OPENWRT_DIR)/.config
-	echo "CONFIG_VERSION_NUMBER=\"$(VERSION)\"" >> $(OPENWRT_DIR)/.config
 	$(UMASK); \
 	  $(MAKE) -C $(OPENWRT_DIR) defconfig
 
 # prepare openwrt working copy
 prepare: stamp-clean-prepared .stamp-prepared
 .stamp-prepared: .stamp-patched $(OPENWRT_DIR)/.config
-	sed -i 's,^# REVISION:=.*,REVISION:=$(REVISION),g' $(OPENWRT_DIR)/include/version.mk
 	touch $@
 
 # compile


### PR DESCRIPTION
Reverts freifunk-berlin/firmware#267

@lynxis , why did you merge this without further discussion? For master(-based) build this effectively sets the version to "15.05" now, breaking firmware filenames and migration. People who update to one of these firmwares will permanently break migration, see last lines of https://github.com/freifunk-berlin/firmware-packages/blob/master/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh .