### PR TITLE
[feeds] update packages feed to HEAD of release branch 15.05/CC

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,4 +1,4 @@
-src-git packages git://github.com/openwrt/packages.git^e96cf8db9128e6f71cfe36cc0d986406f60d4432
+src-git packages git://github.com/openwrt/packages.git^8a70ddefc782fd955080a6eba2cfc2578d057c6e
 src-git luci git://github.com/openwrt/luci.git^a66c08849a95ad653635b9d8aefe5a8ecb2382f8
 src-git routing git://github.com/openwrt-routing/packages.git^9b33760b99f87ea3ee472dbbdbd84d7b31304d90
 src-git packages_berlin git://github.com/freifunk-berlin/firmware-packages.git^e62afa705ae8d145b7e483d2a394752636f62e6d


### PR DESCRIPTION
Included changes:

8a70dde unzip: patch CVE-2015-7696, CVE-2015-7697 and integer underflow
f8a70fc madplay: some build variant related fixes
6f8928a node: disable MIPS16
375b9ae python: fix two build depend issues
ffd3b19 gnutls: update to 3.4.6
f690a75 node-cylon: dont double build firmata and serialport
25a4a2f libupm: add fixes for 2 sensors
fbef79f swig: make it compile even if pcre libs are not available
3740ab8 node: add a python/host dependency
5d079de zabbix: enable IPv6 support
c86d2d5 swig: add PKG_LICENSE_FILE
56e6a67 node-hid: set proper version and revision
a0baae4 node-hid: set proper version and revision
02d6846 node-cylon: add proper download path and set version properly
8133570 node-arduino-firmata: set proper download path and set version properly
0c2c464 madplay: add PKG_RELEASE and keep oss variants name
224ead0 madplay: add alsa build variant
d88a149 yunbridge: add linux side python code
d313c7b libupm: add package
e3d8291 libmraa: add mraa including mips platform code
4fb1eda nodejs: add 0.12 version of node
756a24c swig: add host build
61d0f26 Merge pull request #1791 from MikePetullo/for-15.05-krb5
9f3881f python-serial: backport from master branch to for-15.05
fc21520 cgi-io: add a small helper cgi that can be used by RPCD based UIs
9d042c3 spi-tools: add new package
7f3ef93 xl2tpd: bump version
6d892fb python: add dependency to bz2 host build
eb1254a squild: bump version to 3.5.9
085fdc9 lxc: bump version to 1.1.3
3831a68 file: bump version to 5.25
2a1409b e2guardian: bump version to 3.2.0
77e4444 xl2tpd: fix by backporting the version from master branch
5fd21e2 mosquitto: update to 1.4.4
b86ffea libtasn1: updated to 4.7
4c75da6 gnutls: updated to 3.4.5
41a5ec5 radcli: updated to 1.2.3
088c1a1 Merge pull request #1794 from MikePetullo/for-15.05-lighttpd
57ec0c9 lighttpd: update to 1.4.37
b2869e2 lighttpd: update to 1.4.37
6e1a70a krb5: update to 1.13.2
9cadde2 tracertools: update source URL
ad00330 sudo: upgrade to version 1.8.14p3
12b1f4f sudo: preserve sudoers.d during sysupgrade
9f63667 Merge pull request #1733 from hnyman/collectd-entropy
2bcaf5f mdnsresponder: fix fd leak for IPv6 sockets
e7c01b1 tcsh: update source mirrors
8a0cba2 Merge pull request #1762 from pdxmeshnet/for-15.05
d06a94b haproxy: fixes from upstream
5f24380 luarocks: update to 2.2.2
fd2374e knot: update to 1.6.5
dadc400 knot: update to 1.6.4
9ea5f36 zmq: Make 2 variants, refresh patches, fix C++ build issues
4b1cf93 libzmq upgrade to 4.1.1 lzmq upgrade to 0.4.3
9b2d4f8 lzmq: Use smaller .tar.gz  source package
f387d3c strongswan: bump to 5.3.3
997c932 strongswan: make kmod-ipsec6 dependency conditional
29d1085 strongswan: add a couple more plugins
046f800 strongswan: dont overwrite ipsec.conf and ipsec.user during upgrade
19cf8c6 strongswan: split out libtls.so as a separate package.
1deb958 strongswan: Added strongswan-mod-eap-tls
da18070 strongswan: add more exceptions to musl-fixes
69ad693 strongswan: refresh musl compatibility fixes
e51b71a haproxy: fixes from upstream
cad6bb8 unixodbc: bump to version 2.3.4
985d5c3 unixodbc: update to 2.3.3
241a8ad ocserv: updated to 0.10.8
7f6a237 openconnect: corrected port descriptions in README
c773d4a ocserv: more explicit documentation
52bf9d5 ocserv: updated to 0.10.6
9af392d collectd: backport "Clarify config file example/placeholder" from #1736
42f2974 collectd: backport the enablement of entropy plugin to for-15.05
877e9fb vpnc: bump release
5ff1b7a vpnc: corrected call to proto_add_host_dependency
cb5b508 vpnc: fix musl compatibility
37f1c3f Merge pull request #1753 from zorun/bmon_15.05_
1a78a48 bmon: Add missing runtime dependency: terminfo
250b11a sqm-scripts: Bump to v1.0.3.
ffda9cc [bind] Update to 9.9.7-P3 to fix CVE-2015-5722 and CVE-2015-5986
4e3085c bind: update to version 9.9.7-p2
f5c70ea xz: add xz-utils meta package Signed-off-by: Alexander Ryzhov <openwrt@ryzhov-al.ru>
b721a1d libevent: update to 1.4.15 (fixes CVE-2014-6272)
114b6ce Merge pull request #1728 from roger-/micropython-15.05
0b1509c micropython: update to latest
d32e986 python: remove bz2 build dep
e778bd4 openconnect: disabled the resolving code from ppp in netifd script
47a400a avrdude: enable linux-gpio by default
ef9e4d0 bluelog: mark as BROKEN
ee8052d haproxy: fixes for upstream version 1.5.14
de1b148 libuv: fix download path
da6d7b5 python: add dependency to bz2 host build
441da09 zabbix: update to 2.4.6 (and refresh patches)
a6d950b sqlite3: update source to 3.8.11.1
02c1473 Merge pull request #1678 from luizluca/for-15.05-ruby_update
df3c5de ruby: bump version to 2.2.3
01717c0 lighttpd: backport a fix for running out of filedescriptors
a7d66ce apache: bump to version 2.2.31
b51c61c libidn: Update to 1.32
74a1d01 gnutls: updated to 3.4.4
1ee31bd netperf: update to v2.7.0
aa75904 Adopt the netperf package.