### PR TITLE
improve version-file and build-hash into filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ TARGET_CONFIG=$(FW_DIR)/configs/$(TARGET).config
 IB_BUILD_DIR=$(FW_DIR)/imgbldr_tmp
 FW_TARGET_DIR=$(FW_DIR)/firmwares/$(TARGET)
 UMASK=umask 022
-BUILD_REV=~git$(shell git describe --always)
+BUILD_REV_tmp=$(shell git describe --always)
+BUILD_REV=~git$(BUILD_REV_tmp)
 
 # if any of the following files have been changed: clean up openwrt dir
 DEPS=$(TARGET_CONFIG) feeds.conf patches $(wildcard patches/*)
@@ -72,6 +73,12 @@ patch: stamp-clean-patched .stamp-patched
 	touch $@
 
 .stamp-build_rev: .FORCE
+# temp compare both REvision strings
+ifneq ($(REVISION),$(BUILD_REV_tmp))
+	echo "git describe --always different from git log -1"
+	exit 1
+endif
+# end temp
 ifneq (,$(wildcard .stamp-build_rev))
 ifneq ($(shell cat .stamp-build_rev),$(BUILD_REV))
 	echo $(BUILD_REV) | diff >/dev/null -q $@ - || echo -n $(BUILD_REV) >$@

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ IB_BUILD_DIR=$(FW_DIR)/imgbldr_tmp
 FW_TARGET_DIR=$(FW_DIR)/firmwares/$(TARGET)
 UMASK=umask 022
 BUILD_REV_tmp=$(shell git describe --always)
-BUILD_REV=~git$(BUILD_REV_tmp)
+BUILD_REV=.git$(BUILD_REV_tmp)
 
 # if any of the following files have been changed: clean up openwrt dir
 DEPS=$(TARGET_CONFIG) feeds.conf patches $(wildcard patches/*)

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ include config.mk
 MAINTARGET=$(word 1, $(subst _, ,$(TARGET)))
 SUBTARGET=$(word 2, $(subst _, ,$(TARGET)))
 
-GIT_BRANCH=$(shell git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
-REVISION=$(shell git log -1 --format=format:%h)
+GIT_REPO=git config --get remote.origin.url
+GIT_BRANCH=git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,'
+REVISION=git log -1 --format=format:%h
 
 # set dir and file names
 FW_DIR=$(shell pwd)
@@ -74,7 +75,7 @@ patch: stamp-clean-patched .stamp-patched
 
 .stamp-build_rev: .FORCE
 # temp compare both REvision strings
-ifneq ($(REVISION),$(BUILD_REV_tmp))
+ifneq ($(shell $(REVISION)),$(BUILD_REV_tmp))
 	echo "git describe --always different from git log -1"
 	exit 1
 endif
@@ -97,7 +98,7 @@ $(OPENWRT_DIR)/.config: .stamp-feeds-updated $(TARGET_CONFIG) .stamp-build_rev
 # prepare openwrt working copy
 prepare: stamp-clean-prepared .stamp-prepared
 .stamp-prepared: .stamp-patched $(OPENWRT_DIR)/.config
-	sed -i 's,^# REVISION:=.*,REVISION:=$(REVISION),g' $(OPENWRT_DIR)/include/version.mk
+	sed -i 's,^# REVISION:=.*,REVISION:=$(shell $(REVISION)),g' $(OPENWRT_DIR)/include/version.mk
 	touch $@
 
 # compile
@@ -146,11 +147,20 @@ firmwares: stamp-clean-firmwares .stamp-firmwares
 	done
 	mkdir -p $(FW_TARGET_DIR)
 	# Create version info file
-	GIT_BRANCH_ESC=$(shell echo $(GIT_BRANCH) | tr '/' '_'); \
+	GIT_BRANCH_ESC=$(shell $(GIT_BRANCH) | tr '/' '_'); \
 	VERSION_FILE=$(FW_TARGET_DIR)/VERSION.txt; \
-	echo "git branch \"$(GIT_BRANCH)\", revision $(REVISION)" > $$VERSION_FILE; \
+	echo "git branch \"$$GIT_BRANCH_ESC\", revision $(shell $(REVISION))" > $$VERSION_FILE; \
 	echo "https://github.com/freifunk-berlin/firmware" >> $$VERSION_FILE; \
 	echo "https://wiki.freifunk.net/Berlin:Firmware" >> $$VERSION_FILE; \
+	# add feed revisions \
+	for FEED in `cd $(OPENWRT_DIR); ./scripts/feeds list -n`; do \
+	  FEED_DIR=$(addprefix $(OPENWRT_DIR)/feeds/,$$FEED); \
+	  FEED_GIT_REPO=`cd $$FEED_DIR; $(GIT_REPO)`; \
+	  FEED_GIT_BRANCH_ESC=`cd $$FEED_DIR; $(GIT_BRANCH) | tr '/' '_'`; \
+	  FEED_REVISION=`cd $$FEED_DIR; $(REVISION)`; \
+	  echo "Feed $$FEED: repository from $$FEED_GIT_REPO" >> $$VERSION_FILE; \
+	  echo "  git branch \"$$FEED_GIT_BRANCH_ESC\", revision $$FEED_REVISION" >> $$VERSION_FILE; \
+	done
 	# copy different firmwares (like vpn, minimal) including imagebuilder
 	for DIR_ABS in $(IB_BUILD_DIR)/imgbldr/bin/*; do \
 	  TARGET_DIR=$(FW_TARGET_DIR)/$$(basename $$DIR_ABS); \


### PR DESCRIPTION
this adds following to VERSION.txt
- Repository-URL of Feed
- Branch-name of Feed
- Commit-hash of Feed
also have commit-hash of firmware in resulting filenames and insode build image

detection of Release-version and not including commmit-hash will be done later

@sarumpaet 
results can be seen http://buildbot.berlin.freifunk.net/builders/ramips/builds/72