### PR TITLE
Fix '/etc/init.d/olsrd6 restart' breaks IPv4 SmartGateway.

### DIFF
--- a/patches/023-olsrd-smartgw-rules.patch
+++ b/patches/023-olsrd-smartgw-rules.patch
@@ -1,0 +1,35 @@
+Index: openwrt/feeds/routing/olsrd/files/olsrd.init
+===================================================================
+--- openwrt.orig/feeds/routing/olsrd/files/olsrd.init	2016-03-03 00:06:12.447611233 +0100
++++ openwrt/feeds/routing/olsrd/files/olsrd.init	2016-03-03 20:15:26.966597954 +0100
+@@ -703,16 +703,24 @@
+ 	IP6T=$(which ip6tables)
+ 
+ 	# Delete smartgw firewall rules first
+-	for IPT in $IP4T $IP6T; do
+-		while $IPT -D forwarding_rule -o tnl_+ -j ACCEPT 2> /dev/null; do :;done
++	if [ "$UCI_CONF_NAME" == "olsrd6" ]; then
++		while $IP6T -D forwarding_rule -o tnl_+ -j ACCEPT 2> /dev/null; do :;done
+ 		for IFACE in $wanifnames; do
+-			while $IPT -D forwarding_rule -i tunl0 -o $IFACE -j ACCEPT 2> /dev/null; do :; done
++			while $IP6T -D forwarding_rule -i tunl0 -o $IFACE -j ACCEPT 2> /dev/null; do :; done
+ 		done
+ 		for IFACE in $ifsglobal; do
+-			while $IPT -D input_rule -i $IFACE -p 4 -j ACCEPT 2> /dev/null; do :; done
++			while $IP6T -D input_rule -i $IFACE -p 4 -j ACCEPT 2> /dev/null; do :; done
+ 		done
+-	done
+-	while $IP4T -t nat -D postrouting_rule -o tnl_+ -j MASQUERADE 2> /dev/null; do :;done
++	else
++		while $IP4T -D forwarding_rule -o tnl_+ -j ACCEPT 2> /dev/null; do :;done
++		for IFACE in $wanifnames; do
++			while $IP4T -D forwarding_rule -i tunl0 -o $IFACE -j ACCEPT 2> /dev/null; do :; done
++		done
++		for IFACE in $ifsglobal; do
++			while $IP4T -D input_rule -i $IFACE -p 4 -j ACCEPT 2> /dev/null; do :; done
++		done
++		while $IP4T -t nat -D postrouting_rule -o tnl_+ -j MASQUERADE 2> /dev/null; do :;done
++	fi
+ 
+ 	if [ "$smartgateway" == "yes" ]; then
+ 		log "$funcname() Notice: Inserting firewall rules for SmartGateway"

--- a/patches/series
+++ b/patches/series
@@ -8,3 +8,4 @@
 017-luci-bootstrap-input-css.patch
 021-fix-mt7620-failsafe.patch
 022-rt2x00_allow_adhoc_and_ap.patch
+023-olsrd-smartgw-rules.patch


### PR DESCRIPTION
Restarting olsrd for IPv6 clears SmartGateway firewall rules for both IPv4
and IPv6, and does not restore the IPv4 rules. As a result, IPv4 SmartGateway
functionality is broken after /etc/init.d/olsrd6 restart.
Add a patch to the olsrd package to fix this problem.