### PR TITLE
fix: update feed routing to master/05fa82f

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,4 +1,4 @@
 src-git packages git://github.com/openwrt/packages.git^8a70ddefc782fd955080a6eba2cfc2578d057c6e
 src-git luci git://github.com/openwrt/luci.git^a66c08849a95ad653635b9d8aefe5a8ecb2382f8
-src-git routing git://github.com/openwrt-routing/packages.git^0a2aac2dd52e39b84c3f77b3a908adb0f08c9ec7
+src-git routing git://github.com/openwrt-routing/packages.git^05fa82f8789fce820f540d30e635dd24fb72cd1f
 src-git packages_berlin git://github.com/freifunk-berlin/firmware-packages.git^e62afa705ae8d145b7e483d2a394752636f62e6d


### PR DESCRIPTION
includes:
- oonf 0.11.2
- move to Github-repository of olsr.org
- fix for olsrd smartgateway syntax

this also mainly fixes the build fails, as of moved OLSR-repo-location