### PR TITLE
remove opkg on 4MB devices

### DIFF
--- a/packages/default_4MB.sh
+++ b/packages/default_4MB.sh
@@ -9,6 +9,13 @@ rm -vf usr/lib/lua/luci/i18n/olsr.*
 echo "deleting opkg status-files ..."
 rm -rf usr/lib/opkg
 rm -rf etc/opkg*
+# see https://github.com/freifunk-berlin/firmware/pull/341 &
+#  https://github.com/freifunk-berlin/firmware/issues/262
+cat > lib/upgrade/keep.d/freiunk-berlin_no-opkg-info-on-4mb-workaround <<KEEPLIST
+/etc/iproute2/rt_tables
+/etc/firewall.user
+/etc/vnstat.conf
+KEEPLIST
 # as this will be included into image for some reason, even it's
 # not listed for inclusion
 echo "manually removing usign ..."

--- a/packages/default_4MB.sh
+++ b/packages/default_4MB.sh
@@ -6,3 +6,11 @@
 
 echo "Deleting OLSR i18n files..."
 rm -vf usr/lib/lua/luci/i18n/olsr.*
+echo "deleting opkg status-files ..."
+rm -rf usr/lib/opkg
+rm -rf etc/opkg*
+# as this will be included into image for some reason, even it's
+# not listed for inclusion
+echo "manually removing usign ..."
+rm usr/bin/usign
+rm usr/bin/signify

--- a/packages/default_4MB.txt
+++ b/packages/default_4MB.txt
@@ -7,6 +7,8 @@
 -ppp
 -ppp-mod-pppoe
 -wpad
+-opkg
+-usign
 
 # Defaults
 freifunk-berlin-dhcp-defaults

--- a/patches/016-imagebuilder-custom-postinst-script.patch
+++ b/patches/016-imagebuilder-custom-postinst-script.patch
@@ -3,12 +3,12 @@ Index: firmware/openwrt/target/imagebuilder/files/Makefile
 --- openwrt.orig/target/imagebuilder/files/Makefile	2015-04-07 00:27:34.000000000 +0200
 +++ openwrt/target/imagebuilder/files/Makefile	2015-04-09 01:28:05.000000000 +0200
 @@ -111,6 +111,9 @@
- ifneq ($(USER_FILES),)
  	$(MAKE) copy_files
  endif
+ 	$(MAKE) package_postinst
 +ifneq ($(CUSTOM_POSTINST_SCRIPT),)
 +	(cd "$(TARGET_DIR)" ; bash $(CUSTOM_POSTINST_SCRIPT))
 +endif
- 	$(MAKE) package_postinst
  	$(MAKE) build_image
  
+ package_index: FORCE


### PR DESCRIPTION
with current build there is not enough space on jffs, which fails some boot-scripts (e.g. no generation of SSH-keys)

before:
> Firmware Berlin (kathleen 0.2.0-alpha+518d4fa rev 518d4fa)
root@OpenWrt:/# df -h
Filesystem                Size      Used Available Use% Mounted on
rootfs                  320.0K    260.0K     60.0K  81% /

after:
>  Firmware Berlin (kathleen 0.2.0-alpha+c4fa160 rev c4fa160)
root@OpenWrt:/# df -h
Filesystem                Size      Used Available Use% Mounted on
rootfs                  384.0K    244.0K    140.0K  64% /
