### PR TITLE
Makefile: include common.config before $(TARGET).config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REVISION=git describe --always
 # set dir and file names
 FW_DIR=$(shell pwd)
 OPENWRT_DIR=$(FW_DIR)/openwrt
-TARGET_CONFIG=$(FW_DIR)/configs/$(TARGET).config $(FW_DIR)/configs/common.config
+TARGET_CONFIG=$(FW_DIR)/configs/common.config $(FW_DIR)/configs/$(TARGET).config
 IB_BUILD_DIR=$(FW_DIR)/imgbldr_tmp
 FW_TARGET_DIR=$(FW_DIR)/firmwares/$(TARGET)
 UMASK=umask 022


### PR DESCRIPTION
When including first the common.config the target config can override certain symbols
if needed. Make a target more flexible.