### PR TITLE
Makefile: ensure quilt push -a can't fail when already on top of the …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,9 @@ pre-patch: stamp-clean-pre-patch .stamp-pre-patch
 # patch openwrt working copy
 patch: stamp-clean-patched .stamp-patched
 .stamp-patched: .stamp-pre-patch
+	# quilt push -a might fail if already applied all patches
+	# call quilt pop -a to go to the bottom. ignore return code of quilt pop -a
+	-cd $(OPENWRT_DIR); quilt pop -a
 	cd $(OPENWRT_DIR); quilt push -a
 	touch $@
 


### PR DESCRIPTION
…patchset

`quilt push -a` fails if a patch is broken, but also fails when calling
it on a patch series which is already applied. For this reason we can
not ignore the return code of `quilt push -a`.
Calling `quilt pop -a` and ignore it's return code before calling
`quilt push -a` fix this problem.