### PR TITLE
Makefile: OpenWRT-config should be updated after all is patched

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ else
 endif
 
 # openwrt config
-$(OPENWRT_DIR)/.config: .stamp-feeds-updated $(TARGET_CONFIG) .stamp-build_rev
+$(OPENWRT_DIR)/.config: .stamp-patched $(TARGET_CONFIG) .stamp-build_rev
 	cat $(TARGET_CONFIG) >$(OPENWRT_DIR)/.config
 	sed -i "/^CONFIG_VERSION_NUMBER=/ s/\"$$/\+$(FW_REVISION)\"/" $(OPENWRT_DIR)/.config
 	$(UMASK); \


### PR DESCRIPTION
- update OpenWRT
- update and install feeds
- patch all
- then run OpenWRT defconfig

this will prevent a patch which changes a feed-config-paramter to fail to apply