### PR TITLE
fix VERSION_REPO override by passing it to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ FW_REVISION=$(shell $(REVISION))
 ifndef BUILDTYPE
 $(error BUILDTYPE is not set)
 endif
+ifeq ($(filter release unstable,$(BUILDTYPE)),)
+ $(error invalid BUILDTYPE "$(BUILDTYPE)")
+endif
 
 default: firmwares
 

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,11 @@ firmwares: stamp-clean-firmwares .stamp-firmwares
 	rm -rf $(IB_BUILD_DIR)
 	mkdir -p $(IB_BUILD_DIR)
 	$(eval TOOLCHAIN_PATH := $(shell printf "%s:" $(OPENWRT_DIR)/staging_dir/toolchain-*/bin))
+ifeq ($(BUILDTYPE),unstable)
 	$(eval IB_FILE := $(shell ls $(OPENWRT_DIR)/bin/$(MAINTARGET)/OpenWrt-ImageBuilder-*+$(FW_REVISION)*.tar.bz2))
+else
+	$(eval IB_FILE := $(shell ls $(OPENWRT_DIR)/bin/$(MAINTARGET)/OpenWrt-ImageBuilder-*.tar.bz2))
+endif
 	cd $(IB_BUILD_DIR); tar xf $(IB_FILE)
 	# shorten dir name to prevent too long paths
 	mv $(IB_BUILD_DIR)/$(shell basename $(IB_FILE) .tar.bz2) $(IB_BUILD_DIR)/imgbldr
@@ -191,7 +195,11 @@ firmwares: stamp-clean-firmwares .stamp-firmwares
 	# copy imagebuilder, sdk and toolchain (if existing)
 	# remove old versions
 	rm -f $(FW_TARGET_DIR)/OpenWrt-*.tar.bz2
+ifeq ($(BUILDTYPE),unstable)
 	cp -a $(OPENWRT_DIR)/bin/$(MAINTARGET)/OpenWrt-*+$(FW_REVISION)*.tar.bz2 $(FW_TARGET_DIR)/
+else
+	cp -a $(OPENWRT_DIR)/bin/$(MAINTARGET)/OpenWrt-*.tar.bz2 $(FW_TARGET_DIR)/
+endif
 	# copy packages
 	PACKAGES_DIR="$(FW_TARGET_DIR)/packages"; \
 	rm -rf $$PACKAGES_DIR; \

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ openwrt-clean: stamp-clean-openwrt-cleaned .stamp-openwrt-cleaned
 	  rm -rf bin .config feeds.conf build_dir/target-* logs/
 	touch $@
 
+openwrt-clean-bin:
+	rm -rf $(OPENWRT_DIR)/bin
+
 # update openwrt and checkout specified commit
 openwrt-update: stamp-clean-openwrt-updated .stamp-openwrt-updated
 .stamp-openwrt-updated: .stamp-openwrt-cleaned
@@ -110,7 +113,7 @@ endif
 
 # compile
 compile: stamp-clean-compiled .stamp-compiled
-.stamp-compiled: .stamp-prepared
+.stamp-compiled: .stamp-prepared openwrt-clean-bin
 	$(UMASK); \
 	  $(MAKE) -C $(OPENWRT_DIR) $(MAKE_ARGS)
 	touch $@
@@ -204,6 +207,6 @@ stamp-clean:
 
 clean: stamp-clean .stamp-openwrt-cleaned
 
-.PHONY: openwrt-clean openwrt-update patch feeds-update prepare compile firmwares stamp-clean clean
+.PHONY: openwrt-clean openwrt-update openwrt-clean-bin patch feeds-update prepare compile firmwares stamp-clean clean
 .NOTPARALLEL:
 .FORCE:

--- a/Makefile
+++ b/Makefile
@@ -96,11 +96,15 @@ $(OPENWRT_DIR)/.config: .stamp-feeds-updated $(TARGET_CONFIG)
 	  $(MAKE) -C $(OPENWRT_DIR) defconfig
 
 # prepare openwrt working copy
-prepare: stamp-clean-prepared .stamp-prepared .stamp-build_rev
-.stamp-prepared: .stamp-patched $(OPENWRT_DIR)/.config
-	sed -i 's,^# REVISION:=.*,REVISION:=$(FW_REVISION),g' $(OPENWRT_DIR)/include/version.mk
+prepare: stamp-clean-prepared .stamp-prepared
+.stamp-prepared: .stamp-patched $(OPENWRT_DIR)/.config .stamp-build_rev
+	# look for correct REVISION or set just replace the line with the correct
+	grep -q REVISION:=$(FW_REVISION) $(OPENWRT_DIR)/include/version.mk || \
+	  sed -i "/REVISION:=/c\REVISION:=$(FW_REVISION)" $(OPENWRT_DIR)/include/version.mk
 ifeq ($(BUILDTYPE),unstable)
-	sed -i "/^CONFIG_VERSION_NUMBER=/ s/\"$$/\+$(FW_REVISION)\"/" $(OPENWRT_DIR)/.config
+	sed -i "/^CONFIG_VERSION_NUMBER=/d" $(OPENWRT_DIR)/.config
+	cat $(TARGET_CONFIG)|grep -e "^CONFIG_VERSION_NUMBER=" | \
+	  sed "/^CONFIG_VERSION_NUMBER=/ s/\"$$/\+$(FW_REVISION)\"/" >>$(OPENWRT_DIR)/.config
 endif
 	touch $@
 

--- a/config.mk
+++ b/config.mk
@@ -5,3 +5,5 @@ PACKAGES_LIST_DEFAULT=default backbone
 OPENWRT_SRC=git://git.openwrt.org/15.05/openwrt.git
 OPENWRT_COMMIT=64e116779c0f7da6d98068b8e7c50f528c8a91f2
 MAKE_ARGS=
+#BUILDTYPE - unstable / release
+BUILDTYPE=unstable


### PR DESCRIPTION
This implements the way of setting the URL of the OpenWRT-package-repo as planned by https://github.com/freifunk-berlin/buildbot/pull/34.

This supersedes PR #354 and reflects comments:
- "openwrt-clean-bin should be moved into a seperate commit"
- "A clean build should only contain one single file matching the regex OpenWrt-ImageBuilder-*.tar.bz2" --> put this into a separate commit, which can be removed if this "hack" is not needed