### PR TITLE
Makefile: add target openwrt-clean-bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,15 @@ $(OPENWRT_DIR):
 
 # clean up openwrt working copy
 openwrt-clean: stamp-clean-openwrt-cleaned .stamp-openwrt-cleaned
-.stamp-openwrt-cleaned: config.mk | $(OPENWRT_DIR)
+.stamp-openwrt-cleaned: config.mk | $(OPENWRT_DIR) openwrt-clean-bin
 	cd $(OPENWRT_DIR); \
 	  ./scripts/feeds clean && \
 	  git clean -dff && git fetch && git reset --hard HEAD && \
-	  rm -rf bin .config feeds.conf build_dir/target-* logs/
+	  rm -rf .config feeds.conf build_dir/target-* logs/
 	touch $@
+
+openwrt-clean-bin:
+	rm -rf $(OPENWRT_DIR)/bin
 
 # update openwrt and checkout specified commit
 openwrt-update: stamp-clean-openwrt-updated .stamp-openwrt-updated
@@ -97,7 +100,7 @@ prepare: stamp-clean-prepared .stamp-prepared
 
 # compile
 compile: stamp-clean-compiled .stamp-compiled
-.stamp-compiled: .stamp-prepared
+.stamp-compiled: .stamp-prepared openwrt-clean-bin
 	$(UMASK); \
 	  $(MAKE) -C $(OPENWRT_DIR) $(MAKE_ARGS)
 	touch $@
@@ -197,6 +200,6 @@ unpatch: $(OPENWRT_DIR)/patches
 
 clean: stamp-clean .stamp-openwrt-cleaned
 
-.PHONY: openwrt-clean openwrt-update patch feeds-update prepare compile firmwares stamp-clean clean
+.PHONY: openwrt-clean openwrt-clean-bin openwrt-update patch feeds-update prepare compile firmwares stamp-clean clean
 .NOTPARALLEL:
 .FORCE:

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ firmwares: stamp-clean-firmwares .stamp-firmwares
 	rm -rf $(IB_BUILD_DIR)
 	mkdir -p $(IB_BUILD_DIR)
 	$(eval TOOLCHAIN_PATH := $(shell printf "%s:" $(OPENWRT_DIR)/staging_dir/toolchain-*/bin))
-	$(eval IB_FILE := $(shell ls $(OPENWRT_DIR)/bin/$(MAINTARGET)/OpenWrt-ImageBuilder-*+$(FW_REVISION)*.tar.bz2))
+	$(eval IB_FILE := $(shell ls $(OPENWRT_DIR)/bin/$(MAINTARGET)/OpenWrt-ImageBuilder-*.tar.bz2))
 	cd $(IB_BUILD_DIR); tar xf $(IB_FILE)
 	# shorten dir name to prevent too long paths
 	mv $(IB_BUILD_DIR)/$(shell basename $(IB_FILE) .tar.bz2) $(IB_BUILD_DIR)/imgbldr
@@ -178,7 +178,7 @@ firmwares: stamp-clean-firmwares .stamp-firmwares
 	# copy imagebuilder, sdk and toolchain (if existing)
 	# remove old versions
 	rm -f $(FW_TARGET_DIR)/OpenWrt-*.tar.bz2
-	cp -a $(OPENWRT_DIR)/bin/$(MAINTARGET)/OpenWrt-*+$(FW_REVISION)*.tar.bz2 $(FW_TARGET_DIR)/
+	cp -a $(OPENWRT_DIR)/bin/$(MAINTARGET)/OpenWrt-*.tar.bz2 $(FW_TARGET_DIR)/
 	# copy packages
 	PACKAGES_DIR="$(FW_TARGET_DIR)/packages"; \
 	rm -rf $$PACKAGES_DIR; \


### PR DESCRIPTION
this cleans up the build OpenWRT-files before starting a new build. This
might prevent the freifunk-build-process to look for the correct binary-
file on further processing, as there ist only one file.

Since commit 34d519c individual filenames are created per build, which
ended up in having the same type of buildresult in multiple versions.

Please check if prereq for ".stamp-openwrt-cleaned" are correct