### PR TITLE
patches: reference official webpage to check of weekly meetings

### DIFF
--- a/patches/700-banner-info.patch
+++ b/patches/700-banner-info.patch
@@ -34,5 +34,5 @@ Index: openwrt/package/base-files/files/etc/banner
 +   https://github.com/freifunk-berlin/firmware/issues
 +
 + For questions write a mail to <berlin@berlin.freifunk.net>
-+ or come to our weekly meetings at c-base/wikimedia in Berlin.
++ or check https://berlin.freifunk.net/contact for our weekly meetings.
 +


### PR DESCRIPTION
This removes the need to release a new firmware when the meeting-location
changes and gives a central place to announce this.