### PR TITLE
policyrouting - fix for bypassing VPN for client on meshed router

### DIFF
--- a/patches/703-policyrouting_fix_bypass-vpn.patch
+++ b/patches/703-policyrouting_fix_bypass-vpn.patch
@@ -1,0 +1,10 @@
+--- a/feeds/luci/contrib/package/freifunk-policyrouting/files/etc/hotplug.d/iface/30-policyrouting
++++ b/feeds/luci/contrib/package/freifunk-policyrouting/files/etc/hotplug.d/iface/30-policyrouting
+@@ -1,5 +1,7 @@
+ #!/bin/sh
+ 
++[ "$INTERFACE" = wan ] && exit
++
+ . /lib/functions.sh
+ . /lib/functions/network.sh
+ 

--- a/patches/series
+++ b/patches/series
@@ -17,3 +17,4 @@
 700-banner-info.patch
 701-luci-freifunk-policyrouting-berlin.patch
 702-luci-bootstrap-input-css.patch
+703-policyrouting_fix_bypass-vpn.patch


### PR DESCRIPTION
this fixes #402 

by preventing execution of "etc/hotplug.d/iface/30-policyrouting" for interface WAN