### PR TITLE
[WIP] update routing feed

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,6 +1,6 @@
 src-git packages https://github.com/openwrt/packages.git^ed90827282851ad93294e370860320f1af428bb2
 src-git luci https://github.com/openwrt/luci.git^a100738163585ae1edc24d832ca9bef1f34beef0
-src-git routing https://github.com/openwrt-routing/packages.git^dd36dd47bbd75defcb3c517cafe7a19ee425f0af
+src-git routing https://github.com/openwrt-routing/packages.git^a881d5d4a6c4d0a5d9c515525eb83774516d038c
 src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^3186386056cf52ebea3c7298b0a57fa8eafc851e
 
 ##


### PR DESCRIPTION
https://github.com/openwrt-routing/packages/commit/a881d5d4a6c4d0a5d9c515525eb83774516d038c is master, currently
This is related to https://github.com/OLSR/olsrd/issues/21 - olsrd 0.9.5 gets updated to 0.9.6.1 by this fix.

My current Problem is this when I test this:

```
$ /etc/init.d/olsrd start
olsrd: /etc/init.d/olsrd: olsrd_write_loadplugin() Warning: Plugin library '' not found, skipped
olsrd: /etc/init.d/olsrd: olsrd_write_loadplugin() Warning: Plugin library '' not found, skipped
olsrd: /etc/init.d/olsrd: olsrd_write_loadplugin() Warning: Plugin library '' not found, skipped
olsrd: /etc/init.d/olsrd: olsrd_write_loadplugin() Warning: Plugin library '' not found, skipped
```
I can not view the neighbors on the web interface but meshing and Internet works.
I assume, the error messages are from plugins which can not be loaded.

[Blogpost with context](http://niccokunzmann.github.io/blog/2017-03-06/olsr)