### PR TITLE
Makefile make tagets more atomic

### DIFF
--- a/profiles/ar71xx-generic.profiles
+++ b/profiles/ar71xx-generic.profiles
@@ -42,3 +42,7 @@ ubnt-unifiac-lite
 ubnt-unifiac-pro
 ubnt-unifi-outdoor
 ubnt-unifi-outdoor-plus
+WZRHPG300NH2
+WZRHPAG300H
+WZR600DHP
+WZRHPG450H


### PR DESCRIPTION
please only look at the changes in the Makefile

This moves the generation of the VERSION.txt into a separate target and splits up this ugly script-block.

if nobody sees an issue, I'll push only the Makefile-commit onto master.