### PR TITLE
move finalfiles instead of copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ firmwares: stamp-clean-firmwares .stamp-firmwares
 	# remove old versions
 	rm -f $(FW_TARGET_DIR)/*.tar.xz
 	for file in $(LEDE_DIR)/bin/targets/$(MAINTARGET)/$(SUBTARGET)/*{imagebuilder,sdk,toolchain}*.tar.xz; do \
-	  if [ -e $$file ]; then cp -a $$file $(FW_TARGET_DIR)/ ; fi \
+	  if [ -e $$file ]; then mv $$file $(FW_TARGET_DIR)/ ; fi \
 	done
 	# copy packages
 	PACKAGES_DIR="$(FW_TARGET_DIR)/packages"; \


### PR DESCRIPTION
move imagebuilder, sdk, toolchain to final folder to save some space in BUILD_DIR (see issue #414)

I don't see any problem in merging this. Or is there any use of these files in the BUILD_DIR?