### PR TITLE
packages: add tcpdump to the default package set

### DIFF
--- a/packages/default.txt
+++ b/packages/default.txt
@@ -26,6 +26,7 @@ qos-scripts
 firewall
 iwinfo
 libiwinfo-lua
+tcpdump
 
 # GUI-basics
 uhttpd


### PR DESCRIPTION
Tcpdump is a standard debugging tool for network problems. We have
enough space left on 8MB devices to add it to the default set of
packages. Tcpdump is already part of the default set for backbone
devices so we use tcpdump in the default image too.

Discussion:

https://github.com/freifunk-berlin/firmware/issues/464