### PR TITLE
configs: build kmod-nf-nathelper-extra as module

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -82,6 +82,7 @@ CONFIG_PACKAGE_kmod-lib-crc-itu-t=m
 CONFIG_PACKAGE_kmod-lib-crc16=m
 CONFIG_PACKAGE_kmod-lib-crc32c=m
 CONFIG_PACKAGE_kmod-lib-textsearch=m
+CONFIG_PACKAGE_kmod-nf-nathelper-extra=m
 CONFIG_PACKAGE_kmod-nls-utf8=m
 CONFIG_PACKAGE_kmod-nls-iso8859-1=m
 CONFIG_PACKAGE_kmod-nls-iso8859-15=m


### PR DESCRIPTION
The nf-nathelper-extra kernel module enables proper network address
translation for protocols such as pptp, gre, sip.

Package description:

https://lede-project.org/packages/pkgdata/kmod-nf-nathelper-extra