### PR TITLE
Allow ICMP for busybox traceroute (https://dev.openwrt.org/ticket/9212)

### DIFF
--- a/patches/013-busybox-traceroute-allow-icmp.patch
+++ b/patches/013-busybox-traceroute-allow-icmp.patch
@@ -1,0 +1,25 @@
+diff -ur openwrt.orig/package/utils/busybox/Config-defaults.in openwrt/package/utils/busybox/Config-defaults.in
+--- openwrt.orig/package/utils/busybox/Config-defaults.in	2017-07-12 10:47:13.242874481 +0200
++++ openwrt/package/utils/busybox/Config-defaults.in	2017-07-12 11:03:17.000000000 +0200
+@@ -2238,7 +2238,7 @@
+ 	default n
+ config BUSYBOX_DEFAULT_FEATURE_TRACEROUTE_USE_ICMP
+ 	bool
+-	default n
++	default y
+ config BUSYBOX_DEFAULT_TUNCTL
+ 	bool
+ 	default n
+diff -ur openwrt.orig/package/utils/busybox/Makefile openwrt/package/utils/busybox/Makefile
+--- openwrt.orig/package/utils/busybox/Makefile	2017-07-12 10:47:13.242874481 +0200
++++ openwrt/package/utils/busybox/Makefile	2017-07-12 11:03:17.000000000 +0200
+@@ -9,7 +9,7 @@
+
+ PKG_NAME:=busybox
+ PKG_VERSION:=1.23.2
+-PKG_RELEASE:=1
++PKG_RELEASE:=2
+ PKG_FLAGS:=essential
+
+ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+

--- a/patches/series
+++ b/patches/series
@@ -11,6 +11,7 @@
 010-tpl-CPE_enable_LNA.patch
 011-tpl-wr841_names.patch
 012-iwinfo_add_nsm2locoxm.patch
+013-busybox-traceroute-allow-icmp.patch
 200-update-community-profiles.patch
 600-imagebuilder-custom-postinst-script.patch
 700-banner-info.patch


### PR DESCRIPTION
Das aktuelle traceroute lässt sich selbst mit "-I" nicht zur Benutzung von ICMP statt UDP bewegen. Einige Stationen (z.B. Christophorus-Switch TP-Link TL-SG3424P) oder auch Win10 ignorieren leider UDP-Pakete mit abgelaufener TTL und reagieren nur auf entsprechende ICMP Pakete.

Der Patch ändert nichts am Default-Verhalten von traceroute, lediglich wird die Option "-I" nicht mehr einfach ignoriert.

Da die Änderung offenbar auch in "SAm0815_Hedy-alpha_routing-master" noch nicht eingeflossen ist, wäre es hilfreich, sie vorab zu übernehmen, bis sie auch in späteren Lede-Versionen auftaucht.