### PR TITLE
backport Ubiquiti ERX SFP to LEDE 17.01

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ pre-patch: stamp-clean-pre-patch .stamp-pre-patch
 patch: stamp-clean-patched .stamp-patched
 .stamp-patched: .stamp-pre-patch
 	cd $(LEDE_DIR); quilt push -a
+	rm -rf $(LEDE_DIR)/tmp
 	touch $@
 
 .stamp-build_rev: .FORCE
@@ -203,6 +204,7 @@ stamp-clean:
 unpatch: $(LEDE_DIR)/patches
 # RC = 2 of quilt --> nothing to be done
 	cd $(LEDE_DIR); quilt pop -a -f || [ $$? = 2 ] && true
+	rm -rf $(LEDE_DIR)/tmp
 	rm -f .stamp-patched
 
 clean: stamp-clean .stamp-lede-cleaned

--- a/configs/ramips-mt7621.config
+++ b/configs/ramips-mt7621.config
@@ -3,3 +3,6 @@ CONFIG_TARGET_ramips_mt7621=y
 CONFIG_TARGET_ramips_mt7621_Default=y
 CONFIG_PACKAGE_kmod-ath9k-htc=n
 CONFIG_PACKAGE_kmod-mt76=m
+CONFIG_PACKAGE_kmod-gpio-pca953x=m
+CONFIG_PACKAGE_kmod-i2c-algo-bit=m
+CONFIG_PACKAGE_kmod-i2c-gpio=m

--- a/configs/ramips-mt7621.config
+++ b/configs/ramips-mt7621.config
@@ -3,6 +3,3 @@ CONFIG_TARGET_ramips_mt7621=y
 CONFIG_TARGET_ramips_mt7621_Default=y
 CONFIG_PACKAGE_kmod-ath9k-htc=n
 CONFIG_PACKAGE_kmod-mt76=m
-CONFIG_PACKAGE_kmod-i2c-gpio-custom=m
-CONFIG_PACKAGE_kmod-i2c-mt7621=m
-CONFIG_PACKAGE_kmod-i2c-algo-pca=m

--- a/patches/000-add_ubnt-erx-sfp.patch
+++ b/patches/000-add_ubnt-erx-sfp.patch
@@ -1,0 +1,272 @@
+commit 35742c27243982692749931074ce7bf487d6fd08
+Author: Sven Roederer <devel-sven@geroedel.de>
+Date:   Sun Jun 18 23:06:34 2017 +0200
+
+    ramips: cheap backport of "add support for Ubiquiti EdgeRouter X-SFP"
+
+diff --git a/target/linux/ramips/base-files/etc/board.d/02_network b/target/linux/ramips/base-files/etc/board.d/02_network
+index 36cdc10..a9bce12 100755
+--- a/target/linux/ramips/base-files/etc/board.d/02_network
++++ b/target/linux/ramips/base-files/etc/board.d/02_network
+@@ -148,6 +148,7 @@ ramips_setup_interfaces()
+ 	rb750gr3|\
+ 	rt-n14u|\
+ 	ubnt-erx|\
++	ubnt-erx-sfp|\
+ 	ur-326n4g|\
+ 	wrtnode|\
+ 	wrtnode2p | \
+diff --git a/target/linux/ramips/base-files/etc/board.d/03_gpio_switches b/target/linux/ramips/base-files/etc/board.d/03_gpio_switches
+new file mode 100755
+index 0000000..859dfb3
+--- /dev/null
++++ b/target/linux/ramips/base-files/etc/board.d/03_gpio_switches
+@@ -0,0 +1,25 @@
++#!/bin/sh
++
++. /lib/functions/uci-defaults.sh
++. /lib/ramips.sh
++
++board_config_update
++
++board=$(ramips_board_name)
++
++case "$board" in
++ubnt-erx)
++	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "0"
++	;;
++ubnt-erx-sfp)
++	ucidef_add_gpio_switch "poe_power_port0" "PoE Power Port0" "496"
++	ucidef_add_gpio_switch "poe_power_port1" "PoE Power Port1" "497"
++	ucidef_add_gpio_switch "poe_power_port2" "PoE Power Port2" "498"
++	ucidef_add_gpio_switch "poe_power_port3" "PoE Power Port3" "499"
++	ucidef_add_gpio_switch "poe_power_port4" "PoE Power Port4" "500"
++	;;
++esac
++
++board_config_flush
++
++exit 0
+diff --git a/target/linux/ramips/base-files/lib/ramips.sh b/target/linux/ramips/base-files/lib/ramips.sh
+index e642d56..3d19a9a 100755
+--- a/target/linux/ramips/base-files/lib/ramips.sh
++++ b/target/linux/ramips/base-files/lib/ramips.sh
+@@ -466,6 +466,9 @@ ramips_board_detect() {
+ 	*"UBNT-ERX")
+ 		name="ubnt-erx"
+ 		;;
++	*"UBNT-ERX-SFP")
++		name="ubnt-erx-sfp"
++		;;
+ 	*"UR-326N4G")
+ 		name="ur-326n4g"
+ 		;;
+diff --git a/target/linux/ramips/base-files/lib/upgrade/platform.sh b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+index 7f5b1dd..d6f6179 100755
+--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+@@ -234,7 +234,8 @@ platform_check_image() {
+ 		}
+ 		return 0
+ 		;;
+-	ubnt-erx)
++	ubnt-erx|\
++	ubnt-erx-sfp)
+ 		nand_do_platform_check "$board" "$1"
+ 		return $?;
+ 		;;
+@@ -248,7 +249,8 @@ platform_nand_pre_upgrade() {
+ 	local board=$(ramips_board_name)
+ 
+ 	case "$board" in
+-	ubnt-erx)
++	ubnt-erx|\
++	ubnt-erx-sfp)
+ 		platform_upgrade_ubnt_erx "$ARGV"
+ 		;;
+ 	esac
+@@ -258,7 +260,8 @@ platform_pre_upgrade() {
+ 	local board=$(ramips_board_name)
+ 
+ 	case "$board" in
+-    	ubnt-erx)
++    	ubnt-erx|\
++	ubnt-erx-sfp)
+ 		nand_do_upgrade "$ARGV"
+ 		;;
+ 	esac
+diff --git a/target/linux/ramips/dts/UBNT-ERX-SFP.dts b/target/linux/ramips/dts/UBNT-ERX-SFP.dts
+new file mode 100644
+index 0000000..7619a5d
+--- /dev/null
++++ b/target/linux/ramips/dts/UBNT-ERX-SFP.dts
+@@ -0,0 +1,124 @@
++#include <dt-bindings/input/input.h>
++
++/dts-v1/;
++
++#include "mt7621.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++
++/ {
++	model = "UBNT-ERX-SFP";
++	compatible = "ubiquiti,edgerouterx-sfp";
++
++	i2c-gpio {
++		compatible = "i2c-gpio";
++		gpios = <&gpio0 3 GPIO_ACTIVE_HIGH /* sda */
++		         &gpio0 4 GPIO_ACTIVE_HIGH /* scl */
++		        >;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		pca9555@25 {
++			compatible = "pca9555";
++			reg = <0x25>;
++		};
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x10000000>;
++	};
++
++	chosen {
++		bootargs = "console=ttyS0,57600";
++	};
++
++	gpio-keys-polled {
++		compatible = "gpio-keys-polled";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		poll-interval = <20>;
++
++		reset {
++			label = "reset";
++			gpios = <&gpio0 12 1>;
++			linux,code = <KEY_RESTART>;
++		};
++	};
++};
++
++&ethernet {
++	mtd-mac-address = <&factory 0x22>;
++};
++
++&nand {
++	status = "okay";
++
++	partition@0 {
++		label = "u-boot";
++		reg = <0x0 0x80000>;
++		read-only;
++	};
++
++	partition@80000 {
++		label = "u-boot-env";
++		reg = <0x80000 0x60000>;
++		read-only;
++	};
++
++	factory: partition@e0000 {
++		label = "factory";
++		reg = <0xe0000 0x60000>;
++	};
++
++	partition@140000 {
++		label = "kernel1";
++		reg = <0x140000 0x300000>;
++	};
++
++	partition@440000 {
++		label = "kernel2";
++		reg = <0x440000 0x300000>;
++	};
++
++	partition@740000 {
++		label = "ubi";
++		reg = <0x740000 0xf7c0000>;
++	};
++};
++
++&pinctrl {
++	state_default: pinctrl0 {
++		gpio {
++			ralink,group = "uart2", "uart3", "i2c", "pcie", "rgmii2", "jtag";
++			ralink,function = "gpio";
++		};
++	};
++};
++
++&spi0 {
++	/* This board has 2Mb spi flash soldered in and visible
++	   from manufacturer's firmware.
++	   But this SoC shares spi and nand pins,
++	   and current driver does't handle this sharing well */
++	status = "disabled";
++
++	m25p80@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "jedec,spi-nor";
++		reg = <1>;
++		spi-max-frequency = <10000000>;
++		m25p,chunked-io = <32>;
++
++		partition@0 {
++			label = "spi";
++			reg = <0x0 0x200000>;
++			read-only;
++		};
++	};
++};
++
++&xhci {
++	status = "disabled";
++};
+diff --git a/target/linux/ramips/image/mt7621.mk b/target/linux/ramips/image/mt7621.mk
+index 15ea9a1..e7c8af8 100644
+--- a/target/linux/ramips/image/mt7621.mk
++++ b/target/linux/ramips/image/mt7621.mk
+@@ -144,6 +144,19 @@ define Device/ubnt-erx
+ endef
+ TARGET_DEVICES += ubnt-erx
+ 
++define Device/ubnt-erx-sfp
++  DTS := UBNT-ERX-SFP
++  FILESYSTEMS := squashfs
++  KERNEL_SIZE := 3145728
++  KERNEL := $(KERNEL_DTB) | uImage lzma
++  IMAGES := sysupgrade.tar
++  KERNEL_INITRAMFS := $$(KERNEL) | ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
++  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
++  DEVICE_TITLE := Ubiquiti EdgeRouter X-SFP
++  DEVICE_PACKAGES := -kmod-mt76 -kmod-mt7603 -kmod-mt76x2 -kmod-mt76-core -kmod-mac80211 -kmod-cfg80211 -wpad-mini -iwinfo kmod-i2c-core kmod-i2c-algo-bit kmod-i2c-gpio kmod-gpio-pca953x
++endef
++TARGET_DEVICES += ubnt-erx-sfp
++
+ define Device/vr500
+   DTS := VR500
+   IMAGE_SIZE := 66453504
+diff --git a/target/linux/ramips/mt7621/config-4.4 b/target/linux/ramips/mt7621/config-4.4
+index 383370b..b7f7a3d 100644
+--- a/target/linux/ramips/mt7621/config-4.4
++++ b/target/linux/ramips/mt7621/config-4.4
+@@ -70,6 +70,8 @@ CONFIG_GENERIC_TIME_VSYSCALL=y
+ CONFIG_GPIOLIB=y
+ CONFIG_GPIO_DEVRES=y
+ CONFIG_GPIO_MT7621=y
++CONFIG_GPIO_PCA953X=y
++CONFIG_GPIO_PCA953X_IRQ=n
+ # CONFIG_GPIO_RALINK is not set
+ CONFIG_GPIO_SYSFS=y
+ CONFIG_HARDWARE_WATCHPOINTS=y
+@@ -116,6 +118,7 @@ CONFIG_HIGHMEM=y
+ CONFIG_HW_HAS_PCI=y
+ CONFIG_HZ_PERIODIC=y
+ CONFIG_I2C=y
++CONFIG_I2C_GPIO=y
+ CONFIG_I2C_MT7621=y
+ # CONFIG_IMG_MDC_DMA is not set
+ CONFIG_INITRAMFS_SOURCE=""

--- a/patches/series
+++ b/patches/series
@@ -1,3 +1,4 @@
+000-add_ubnt-erx-sfp.patch
 001-rt2x00_allow_adhoc_and_ap.patch
 002-add_ramips-nexx-image.patch
 600-imagebuilder-custom-postinst-script.patch

--- a/profiles/ramips-mt7621.profiles
+++ b/profiles/ramips-mt7621.profiles
@@ -1,1 +1,2 @@
 ubnt-erx
+ubnt-erx-sfp


### PR DESCRIPTION
this patch adds a "cheap" backport of the Ubiquiti ERX-SFT support from LEDE-master to LEDE-17.01. So this patch adds the board "ubnt-erx-sfp" for ramips-mt7621 target.

I call it cheap, because it's not using common parts in a included DTS, just a copy of the ERX-dts modded for ERX-SFP.
also the GPIOs are not working as in Master.