### PR TITLE
hostapd: disable 802.11 legacy-rates by default

### DIFF
--- a/patches/005-hostapd_nolegacy_by_default.patch
+++ b/patches/005-hostapd_nolegacy_by_default.patch
@@ -1,0 +1,13 @@
+diff --git a/package/network/services/hostapd/files/hostapd.sh b/package/network/services/hostapd/files/hostapd.sh
+index 1f28661..378b114 100644
+--- a/package/network/services/hostapd/files/hostapd.sh
++++ b/package/network/services/hostapd/files/hostapd.sh
+@@ -82,7 +82,7 @@ hostapd_prepare_device_config() {
+ 
+ 	set_default country_ie 1
+ 	set_default doth 1
+-	set_default legacy_rates 1
++	set_default legacy_rates 0
+ 
+ 	[ "$hwmode" = "b" ] && legacy_rates=1
+ 

--- a/patches/series
+++ b/patches/series
@@ -2,6 +2,7 @@
 001-rt2x00_allow_adhoc_and_ap.patch
 002-add_ramips-nexx-image.patch
 004-openwrt-release_use_configured_revision.patch
+005-hostapd_nolegacy_by_default.patch
 200-luci_fix_meshid.patch
 300-use_olsrd0903.patch
 201-revert_olsr-status_for_olsr0903.patch


### PR DESCRIPTION
In https://github.com/lede-project/source/commit/e194e1b3c838a301178effb639804c28fe67354d
the option "legacy-rates" was added to uci.wireless.radio. So on a per radio-basis the 802.11b rates can be disabled easily.
LEDE implemented this as having legacy-rates enabled by default, but we want to have them disabled by default. (see https://github.com/freifunk-berlin/firmware/issues/375)

So we change the default of LEDE. This also safes some work in changing the UCI-config on every node.
The node-operator is always free to enable these rates again by adding the legacy_rates option.

This was also tested on a 5GHz radio of a Dualband-router and did no show any side-effects in this band.