### PR TITLE
Reduce disc-space usage on buildbots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,16 @@ FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 VERSION_FILE=$(FW_TARGET_DIR)/VERSION.txt
 UMASK=umask 022
 
-ifdef IS_BUILDBOT
-$(info running on buildslave, maybe special actions will apply ...)
+ifeq ($(SET_BUILDBOT),no)
+undefine IS_BUILDBOT
+else
+ifeq ($(SET_BUILDBOT),yes)
+IS_BUILDBOT=yes
+endif
+endif
+
+ifeq ($(IS_BUILDBOT),yes)
+$(info special actions apply to builds on this host ...)
 endif
 
 # test for existing $TARGET-config or abort

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 VERSION_FILE=$(FW_TARGET_DIR)/VERSION.txt
 UMASK=umask 022
 
+ifdef IS_BUILDBOT
+$(info running on buildslave, maybe special actions will apply ...)
+endif
+
 # test for existing $TARGET-config or abort
 ifeq ($(wildcard $(FW_DIR)/configs/$(TARGET).config),)
 $(error config for $(TARGET) not defined)
@@ -121,6 +125,10 @@ compile: stamp-clean-compiled .stamp-compiled
 .stamp-compiled: .stamp-prepared openwrt-clean-bin
 	$(UMASK); \
 	  $(MAKE) -C $(OPENWRT_DIR) $(MAKE_ARGS)
+# check if running via buildbot and remove the build_dir folder to save some space
+ifdef IS_BUILDBOT
+	rm -rf $(OPENWRT_DIR)/build_dir
+endif
 	touch $@
 
 # fill firmwares-directory with:

--- a/config.mk
+++ b/config.mk
@@ -4,4 +4,5 @@ TARGET=ar71xx-generic
 PACKAGES_LIST_DEFAULT=default vpn03 tunnel-berlin backbone
 OPENWRT_SRC=https://git.openwrt.org/openwrt/openwrt.git
 OPENWRT_COMMIT=d5278cc48b5b08b7aa09c2c3854cf16e5ceae408
+SET_BUILDBOT=env
 MAKE_ARGS=


### PR DESCRIPTION
An approach to fix https://github.com/freifunk-berlin/firmware/issues/414 by adding an option to config.mk (SET_BUILDBOT) for handling the "IS_BUILDBOT" env of https://github.com/freifunk-berlin/buildbot/pull/42