### PR TITLE
Update luci feed

### DIFF
--- a/feeds.conf
+++ b/feeds.conf
@@ -1,5 +1,5 @@
 src-git packages https://github.com/openwrt/packages.git^56331e808f499610c7a3ee295485ad49a9d351e7
-src-git luci https://github.com/openwrt/luci.git^3d46f2593a821960f896e109e1d6f89c481d6004
+src-git luci https://github.com/openwrt/luci.git^c1e6a3dd3ae1be749c8608ffec8d9c90362e17db
 src-git routing https://github.com/openwrt-routing/packages.git^b82d7ccd0abe042359c41229090c2ce5d4276950
 src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^58cc1adf6356b02f43c489cb172f336ec5c7fcf8
 


### PR DESCRIPTION
This should solve issue #523.

c1e6a3dd3ae1be749c8608ffec8d9c90362e17db is the last commit in [the branch lede-17.01 of luci](https://github.com/openwrt/luci/commits/lede-17.01) as of this date.


