### PR TITLE
Move tl-wr710n_v1.0 and tl-wr710n_v2.1 to non-tiny profile

### DIFF
--- a/configs/ar71xx-tiny.config
+++ b/configs/ar71xx-tiny.config
@@ -1,0 +1,10 @@
+CONFIG_TARGET_ar71xx_tiny=y
+CONFIG_PACKAGE_kmod-ath9k-htc=m
+CONFIG_PACKAGE_kmod-ath10k=m
+CONFIG_PACKAGE_ath10k-firmware-qca988x=m
+CONFIG_PACKAGE_ath10k-firmware-qca9888=m
+CONFIG_PACKAGE_kmod-rt2800-lib=m
+CONFIG_PACKAGE_kmod-rt2800-usb=m
+CONFIG_PACKAGE_kmod-rt2x00-lib=m
+CONFIG_PACKAGE_kmod-rt2x00-usb=m
+CONFIG_TARGET_SQUASHFS_BLOCK_SIZE=512

--- a/packages/backbone_4MB.txt
+++ b/packages/backbone_4MB.txt
@@ -54,8 +54,8 @@ olsrd-mod-nameservice
 kmod-ipip
 
 # BATMAN
-kmod-batman-adv
-alfred
-batctl
+#kmod-batman-adv
+#alfred
+#batctl
 
 # Statistics/collectd not included in 4MB image

--- a/profiles/ar71xx-generic.profiles
+++ b/profiles/ar71xx-generic.profiles
@@ -20,6 +20,8 @@ tl-wdr4300-v1
 tl-wdr4300-v1-il
 tl-wdr4310-v1
 tl-wdr4900-v2
+tl-wr710n-v1
+tl-wr710n-v2.1
 tl-wr842n-v1
 tl-wr842n-v2
 tl-wr842n-v3

--- a/profiles/ar71xx-tiny.profiles
+++ b/profiles/ar71xx-tiny.profiles
@@ -3,9 +3,7 @@ tl-mr3220-v2:4MB
 tl-wa801nd-v1:4MB
 tl-wa801nd-v2:4MB
 tl-wa801nd-v3:4MB
-tl-wr710n-v1:4MB
 tl-wr710n-v2:4MB
-tl-wr710n-v2.1:4MB
 tl-wr740n-v1:4MB
 tl-wr740n-v3:4MB
 tl-wr740n-v4:4MB


### PR DESCRIPTION
Only the tl-wr710n_v2 is 4MB device.
The tl-wr710n_v1.0 and tl-wr710n_v2.1 are not recognized as 4MB devices
and should have 8MB according to the tech specs.
https://wiki.openwrt.org/toh/hwdata/tp-link/tp-link_tl-wr710n_v2.0
https://wiki.openwrt.org/toh/hwdata/tp-link/tp-link_tl-wr710n_v1.0_us
https://wiki.openwrt.org/toh/hwdata/tp-link/tp-link_tl-wr710n_v2.1