### PR TITLE
Set "umask 022" for "git clone" and "feed update"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ default: firmwares
 
 # clone openwrt
 $(OPENWRT_DIR):
-	git clone $(OPENWRT_SRC) $(OPENWRT_DIR)
+	$(UMASK); \
+	  git clone $(OPENWRT_SRC) $(OPENWRT_DIR)
 
 # clean up openwrt working copy
 openwrt-clean: stamp-clean-openwrt-cleaned .stamp-openwrt-cleaned
@@ -78,7 +79,7 @@ $(OPENWRT_DIR)/feeds.conf: .stamp-openwrt-updated feeds.conf
 feeds-update: stamp-clean-feeds-updated .stamp-feeds-updated
 .stamp-feeds-updated: $(OPENWRT_DIR)/feeds.conf unpatch
 	cd $(OPENWRT_DIR); ./scripts/feeds uninstall -a
-	cd $(OPENWRT_DIR); ./scripts/feeds update
+	$(UMASK); cd $(OPENWRT_DIR); ./scripts/feeds update
 	cd $(OPENWRT_DIR); ./scripts/feeds install -a
 	touch $@
 


### PR DESCRIPTION
The openwrt files fetched via "git" already need the correct
permissions.

https://github.com/openwrt/luci/issues/1521
https://github.com/freifunk-berlin/firmware/issues/431