### PR TITLE
patches: patch mbedtls to allow 1024 bits RSA

### DIFF
--- a/patches/800-mbedtls-accept-rsa-1024.patch
+++ b/patches/800-mbedtls-accept-rsa-1024.patch
@@ -1,0 +1,17 @@
+Index: openwrt/package/libs/mbedtls/patches/201-accept-rsa-1024.patch
+===================================================================
+--- /dev/null
++++ openwrt/package/libs/mbedtls/patches/201-accept-rsa-1024.patch
+@@ -0,0 +1,12 @@
++--- a/library/x509_crt.c
+++++ b/library/x509_crt.c
++@@ -98,7 +98,7 @@ const mbedtls_x509_crt_profile mbedtls_x
++     MBEDTLS_X509_ID_FLAG( MBEDTLS_MD_SHA512 ),
++     0xFFFFFFF, /* Any PK alg    */
++     0xFFFFFFF, /* Any curve     */
++-    2048,
+++    1024,
++ };
++ 
++ /*
++

--- a/patches/series
+++ b/patches/series
@@ -9,3 +9,4 @@
 701-luci-freifunk-policyrouting-berlin.patch
 703-policyrouting_fix_bypass-vpn.patch
 704-policyrouting_ignore_ffuplink.patch
+800-mbedtls-accept-rsa-1024.patch


### PR DESCRIPTION
Patch mbedtls to allow 1024 bits RSA
for bbb-vpn and VPN03 compatibility

fixes https://github.com/freifunk-berlin/firmware/issues/489