### PR TITLE
disable 802.11s mesh_forwarding by default

### DIFF
--- a/patches/001-mac80211_mesh_no_fwding_by_default.patch
+++ b/patches/001-mac80211_mesh_no_fwding_by_default.patch
@@ -1,0 +1,18 @@
+diff --git a/package/kernel/mac80211/patches/999-mac80211-mesh-no-forwarding-by-default.patch b/package/kernel/mac80211/patches/999-mac80211-mesh-no-forwarding-by-default.patch
+new file mode 100644
+index 0000000000..5bff861737
+--- /dev/null
++++ b/package/kernel/mac80211/patches/999-mac80211-mesh-no-forwarding-by-default.patch
+@@ -0,0 +1,12 @@
++diff -ur backports-2017-11-01/net/wireless/mesh.c backports-2017-11-01.patch/net/wireless/mesh.c
++--- backports-2017-11-01/net/wireless/mesh.c	2018-07-15 15:13:56.230792586 +0200
+++++ backports-2017-11-01.patch/net/wireless/mesh.c	2018-07-22 01:36:13.299928269 +0200
++@@ -68,7 +68,7 @@
++ 	.min_discovery_timeout = MESH_MIN_DISCOVERY_TIMEOUT,
++ 	.dot11MeshHWMPRannInterval = MESH_RANN_INTERVAL,
++ 	.dot11MeshGateAnnouncementProtocol = false,
++-	.dot11MeshForwarding = true,
+++	.dot11MeshForwarding = false,
++ 	.rssi_threshold = MESH_RSSI_THRESHOLD,
++ 	.ht_opmode = IEEE80211_HT_OP_MODE_PROTECTION_NONHT_MIXED,
++ 	.dot11MeshHWMPactivePathToRootTimeout = MESH_PATH_TO_ROOT_TIMEOUT,

--- a/patches/201-wifi_no_meshfwding_by_default.patch
+++ b/patches/201-wifi_no_meshfwding_by_default.patch
@@ -1,0 +1,12 @@
+diff -ur modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua mod-patch/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua
+--- a/feeds/luci/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua	2018-07-22 03:35:34.309103302 +0200
++++ b/feeds/luci/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/wifi.lua	2018-07-22 13:32:28.000000000 +0200
+@@ -370,7 +370,7 @@
+ 
+ meshfwd = s:taboption("advanced", Flag, "mesh_fwding", translate("Forward mesh peer traffic"))
+ meshfwd.rmempty = false
+-meshfwd.default = "1"
++meshfwd.default = "0"
+ meshfwd:depends({mode="mesh"})
+ 
+ ssid = s:taboption("general", Value, "ssid", translate("<abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"))

--- a/patches/series
+++ b/patches/series
@@ -1,7 +1,9 @@
+001-mac80211_mesh_no_fwding_by_default.patch
 002-add_ramips-nexx-image.patch
 004-openwrt-release_use_configured_revision.patch
 005-hostapd_nolegacy_by_default.patch
 200-wifi_nolegacy_rates_by_default.patch
+201-wifi_no_meshfwding_by_default.patch
 600-imagebuilder-custom-postinst-script.patch
 700-banner-info.patch
 701-luci-freifunk-policyrouting-berlin.patch


### PR DESCRIPTION
By default a node must have the internal 802.11s forwarding disabled,to not interfer with the mesh-routing protocols on top.

This is done by patching the kernel-default. Also update the LuCI-frontend to stay in sync.

This was tested with OpenWrt-master, and as the patches apply to OpenWrt-18.06 too, it will work also.