### PR TITLE
Update ar71xx-generic.profiles für Unterstützung MR3020

### DIFF
--- a/profiles/ar71xx-generic.profiles
+++ b/profiles/ar71xx-generic.profiles
@@ -12,6 +12,7 @@ gl-inet-6416A-v1
 OM2P
 OM5PAC
 OM5P
+tl-mr3020-v1:4MB
 tl-mr3220-v1:4MB
 tl-mr3220-v2:4MB
 tl-wa801nd-v1:4MB


### PR DESCRIPTION
Ich habe die Zeile zum kompilieren der Firmware für den MR3020 hinzugefügt. Ich habe die Firmware selbst getestet, sie funktioniert.