### PR TITLE
Finalize "IS_BUILDBOT"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,9 @@ VERSION_FILE=$(FW_TARGET_DIR)/VERSION.txt
 UMASK=umask 022
 
 ifeq ($(SET_BUILDBOT),no)
-undefine IS_BUILDBOT
-else
-ifeq ($(SET_BUILDBOT),yes)
-IS_BUILDBOT=yes
-endif
+override IS_BUILDBOT=no
+else ifeq ($(SET_BUILDBOT),yes)
+override IS_BUILDBOT=yes
 endif
 
 ifeq ($(IS_BUILDBOT),yes)

--- a/Makefile
+++ b/Makefile
@@ -16,15 +16,6 @@ FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 VERSION_FILE=$(FW_TARGET_DIR)/VERSION.txt
 UMASK=umask 022
 
-# This at all is just a temporarly fix for
-# * https://github.com/freifunk-berlin/firmware/issues/414
-# * https://github.com/freifunk-berlin/buildbot/pull/42
-# which enables saving same diskspace during build as buildslave "wg1337"
-# has only a limited RAM-disk used as buildspace
-ifeq ($(shell hostname -f),buildbot)
-SET_BUILDBOT=yes
-endif
-
 ifeq ($(SET_BUILDBOT),no)
 undefine IS_BUILDBOT
 else

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ As you notice there are several different image variants ("backbone", "default",
 These different *packages lists* are defined in `packages/`.
 See the "Features" section above for a description of the purpose of each package list.
 
+### customizing make
+
 `make` will use by default `TARGET` and `PACKAGES_LIST_DEFAULT` defined in
 `config.mk`. You can customize this by overriding them:
 
@@ -167,6 +169,15 @@ The default target is `ar71xx-generic`. At the moment we support the following t
 * x86-generic
 
 You can find configs for these targets in `configs/`.
+
+additional options
+
+* IS_BUILDBOT : 
+  * this will be "yes" when running on the buildbot farm and helps to save some disc-space by removing files not required anymore. On manual builds you should not set this to "yes", as you have to rebuild the whole toolchain each time.
+* SET_BUILDBOT : 
+  * "env" the Makefile will honor the "IS_BUILDBOT" environment
+  * "yes" the Makefile will always act as "IS_BUILDBOT" was set to "yes"
+  * "no"  the Makefile will always act as "IS_BUILDBOT" was set to "no" / is unset. This way we can run builds on the buildbot like a local build.
 
 ### Continuous integration / Buildbot
 


### PR DESCRIPTION
Since https://github.com/freifunk-berlin/buildbot/pull/42 was merged and deployed on the buildbots, we do not need a check for a fixed hostname to detect if we are running on a buildslave. As we get this by an environment now, we can eliminate the "hack".

When on it, just add some words on the environments to the README.