### PR TITLE
Update to master to 18.06 HEAD and PR 174

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -3,6 +3,6 @@ SHELL:=$(shell which bash)
 TARGET=ar71xx-generic
 PACKAGES_LIST_DEFAULT=default tunnel-berlin-openvpn tunnel-berlin-tunneldigger backbone
 OPENWRT_SRC=https://git.openwrt.org/openwrt/openwrt.git
-OPENWRT_COMMIT=5f23d0f3db94155ad4b621f68c18de7ad34d598d
+OPENWRT_COMMIT=753531da249f4960b1088513665982322a2b6a97
 SET_BUILDBOT=env
 MAKE_ARGS=

--- a/feeds.conf
+++ b/feeds.conf
@@ -1,7 +1,7 @@
 src-git packages https://github.com/openwrt/packages.git^8b4118cd7b5b12ccd5a440250951189a6fc10f90
 src-git luci https://github.com/openwrt/luci.git^3dea6b5bc7b95c053724b8ab2bdefd16e6661665
 src-git routing https://github.com/openwrt-routing/packages.git^bc6e7f6903c8237c77131aedfc92dba40e1bc6ac
-src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^1dc61fafaf2ca7f25cbece5a06c1eaea8a163fa5
+src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^ea6d78598a3edf4daca5c72208946364b7d1b136
 src-git gluon https://github.com/freifunk-gluon/packages.git^d2c162fd42e9526a5abb2afbbd6f135ca96e5169
 
 ##

--- a/feeds.conf
+++ b/feeds.conf
@@ -1,7 +1,7 @@
 src-git packages https://github.com/openwrt/packages.git^8b4118cd7b5b12ccd5a440250951189a6fc10f90
 src-git luci https://github.com/openwrt/luci.git^3dea6b5bc7b95c053724b8ab2bdefd16e6661665
-src-git routing https://github.com/openwrt-routing/packages.git^1b9d1c419f0ecefda51922a7845ab2183d6acd76
-src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^ea6d78598a3edf4daca5c72208946364b7d1b136
+src-git routing https://github.com/openwrt-routing/packages.git^bc6e7f6903c8237c77131aedfc92dba40e1bc6ac
+src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^1dc61fafaf2ca7f25cbece5a06c1eaea8a163fa5
 src-git gluon https://github.com/freifunk-gluon/packages.git^c34d129afb48f225741b683127beee6ba3c169d2
 
 ##

--- a/feeds.conf
+++ b/feeds.conf
@@ -1,7 +1,7 @@
 src-git packages https://github.com/openwrt/packages.git^8b4118cd7b5b12ccd5a440250951189a6fc10f90
 src-git luci https://github.com/openwrt/luci.git^3dea6b5bc7b95c053724b8ab2bdefd16e6661665
 src-git routing https://github.com/openwrt-routing/packages.git^bc6e7f6903c8237c77131aedfc92dba40e1bc6ac
-src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^8adb694595b3f2a5275d0191d7d119299c767531
+src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^8b4f15f87627c391462a3fd5249e0169d1d2254b
 src-git gluon https://github.com/freifunk-gluon/packages.git^d2c162fd42e9526a5abb2afbbd6f135ca96e5169
 
 ##

--- a/feeds.conf
+++ b/feeds.conf
@@ -1,4 +1,4 @@
-src-git packages https://github.com/openwrt/packages.git^327a03e8f0c61f8ee98adbee5bd37ce7bccbb049
+src-git packages https://github.com/openwrt/packages.git^8b4118cd7b5b12ccd5a440250951189a6fc10f90
 src-git luci https://github.com/openwrt/luci.git^5ec72617eede467c932642b60291d627fca70342
 src-git routing https://github.com/openwrt-routing/packages.git^1b9d1c419f0ecefda51922a7845ab2183d6acd76
 src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^ea6d78598a3edf4daca5c72208946364b7d1b136

--- a/feeds.conf
+++ b/feeds.conf
@@ -1,5 +1,5 @@
 src-git packages https://github.com/openwrt/packages.git^8b4118cd7b5b12ccd5a440250951189a6fc10f90
-src-git luci https://github.com/openwrt/luci.git^5ec72617eede467c932642b60291d627fca70342
+src-git luci https://github.com/openwrt/luci.git^3dea6b5bc7b95c053724b8ab2bdefd16e6661665
 src-git routing https://github.com/openwrt-routing/packages.git^1b9d1c419f0ecefda51922a7845ab2183d6acd76
 src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^ea6d78598a3edf4daca5c72208946364b7d1b136
 src-git gluon https://github.com/freifunk-gluon/packages.git^c34d129afb48f225741b683127beee6ba3c169d2

--- a/feeds.conf
+++ b/feeds.conf
@@ -2,7 +2,7 @@ src-git packages https://github.com/openwrt/packages.git^8b4118cd7b5b12ccd5a4402
 src-git luci https://github.com/openwrt/luci.git^3dea6b5bc7b95c053724b8ab2bdefd16e6661665
 src-git routing https://github.com/openwrt-routing/packages.git^bc6e7f6903c8237c77131aedfc92dba40e1bc6ac
 src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^1dc61fafaf2ca7f25cbece5a06c1eaea8a163fa5
-src-git gluon https://github.com/freifunk-gluon/packages.git^c34d129afb48f225741b683127beee6ba3c169d2
+src-git gluon https://github.com/freifunk-gluon/packages.git^d2c162fd42e9526a5abb2afbbd6f135ca96e5169
 
 ##
 # just for reference (syntax of different feed-sources)

--- a/feeds.conf
+++ b/feeds.conf
@@ -1,7 +1,7 @@
 src-git packages https://github.com/openwrt/packages.git^8b4118cd7b5b12ccd5a440250951189a6fc10f90
 src-git luci https://github.com/openwrt/luci.git^3dea6b5bc7b95c053724b8ab2bdefd16e6661665
 src-git routing https://github.com/openwrt-routing/packages.git^bc6e7f6903c8237c77131aedfc92dba40e1bc6ac
-src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^ea6d78598a3edf4daca5c72208946364b7d1b136
+src-git packages_berlin https://github.com/freifunk-berlin/firmware-packages.git^8adb694595b3f2a5275d0191d7d119299c767531
 src-git gluon https://github.com/freifunk-gluon/packages.git^d2c162fd42e9526a5abb2afbbd6f135ca96e5169
 
 ##


### PR DESCRIPTION
This PR merges into master updates on all feeds to the latest (as of Dec 19 2018) to the master branch.  This also incorporates PR https://github.com/freifunk-berlin/firmware-packages/pull/174, which should be merged first.
