### PR TITLE
README: link to the wiki-page for enduser relevant informations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,7 @@ New features like a new network concept will be part of future releases.
   * Linux 4.4.167
   * OLSR 0.9.0.3 (downgraded for BBB-VPN compatibility)
   * B.A.T.M.A.N. 2016.5 (with patches of 2019.0)
-* custom package lists for different settings
-  * "default" variant includes ffwizard, openvpn, BATMAN
-  * "default_4MB" like the "default" variant, but excludes public router statistics page (luci-mod-freifunk), monitoring (collectd), BATMAN to fit into boards with 4MB flash
-  * "tunnel-berlin" like default variant and uses the tunnel-service of the Berlin-community via OpenVPN as default uplink
-  * "tunnel-berlin-tunneldigger" like default variant and uses the tunnel-service of the Berlin-community via tunneldigger as default uplink
-  * "tunnel-berlin-tunneldigger_4MB" like the "tunnel-berlin-tunneldigger" variant, but excludes public router statistics page (luci-mod-freifunk), monitoring (collectd), BATMAN to fit into boards with 4MB flash
-  * "vpn03" like default variant and uses the VPN03-service (deprecated) as default uplink
-  * "backbone" variant excludes ffwizard and openvpn, includes more debugging tools
-  * "backbone_4MB" variant excludes ffwizard, luci-mod-freifunk, openvpn, collectd, includes BATMAN and more debugging tools
+* custom package sets for different use cases (see the [Wiki-page](https://wiki.freifunk.net/Berlin:Firmware#Image-Typen))
 * new OLSR setup and configuration:
   * SmartGateway for gateway selection (e.g. honors uplink speed)
   * dynamic gateway plugin for uplink connectivity tests (gwcheck script removed)

--- a/README.md
+++ b/README.md
@@ -1,72 +1,18 @@
-# Freifunk Firmware Berlin "Hedy"
+# Freifunk Berlin Firmware
 https://wiki.freifunk.net/Berlin:Firmware
 
-*[Hedy Lamarr](https://en.wikipedia.org/wiki/Hedy_Lamarr#Inventor) and composer George Antheil developed in 1942 a torpedo guidance system using spread spectrum and frequency hopping technology which is still the base for Wi-Fi and other radio technologies*.
-
-This release removes the hardlinked VPN03-tunnel. Now it is possible to use different flavours of tunnels as well as no tunnel to connect to the internet. Additionally Mesh (11s) is now supported in LuCi to mesh native instead of IBSS. Also it is intended to catch up with current software development and to offer a stable firmware for Freifunk mesh in Berlin.
-
+This is the build-system for the Firmware of Freifunk Berlin.
 The firmware is based on vanilla [OpenWrt](https://openwrt.org/start) with some modifications (to fix
 broken stuff in OpenWrt itself or for example LuCI) and additional default packages/configuration settings.
-New features like a new network concept will be part of future releases.
-
-## Release Note 1.0.2 "Hedy" - 2019-01-21
-* a maintenance release for Hedy-1.0.x-series
-* brings the new feature of changing the uplink preset-type
-* a new uplink-preset "tunnelberlin-tunneldigger"
-* updates to fix security-problems and minor functional problems 
-* images for 
-  * Ubiquiti ERX SFP, TP-Link WR1043ND-v4
-  * support for RaspberryPi and RaspberryPi3 (compile yourself)
-* introduces interface "ffuplink" for a flexible configuration of the wired uplink
-* improved support of 802.11s mesh in LuCI
-* disabling of 802.11b wifi-rates by default
-* in preinit and failsafe the IP-address is 192.168.42.1/24 (like an unconfigured node)
-* the LAN-interface (br-lan) is not providing a default route on a unconfigured node, so manual reconfiguration is required when not using the assistent
-* the assistent will not offer the setup of a private AP anymore
-* when changing or initially confiuring VLANs (via LuCI) the interfacenames will also be changed (should fix #388)
-
-## Features
-* based on [OpenWrt](https://openwrt.org/start) v17.01.6+ (lede-17.01 branch)
-  * Linux 4.4.167
-  * OLSR 0.9.0.3 (downgraded for BBB-VPN compatibility)
-  * B.A.T.M.A.N. 2016.5 (with patches of 2019.0)
-* custom package sets for different use cases (see the [Wiki-page](https://wiki.freifunk.net/Berlin:Firmware#Image-Typen))
-* new OLSR setup and configuration:
-  * SmartGateway for gateway selection (e.g. honors uplink speed)
-  * dynamic gateway plugin for uplink connectivity tests (gwcheck script removed)
-    on hosts: 85.214.20.141, 80.67.169.40, 194.150.168.168
-* a configuration [wizard](https://github.com/freifunk-berlin/packages-berlin/tree/master/utils/luci-app-ffwizard-berlin)
-  * starts after first boot and guides new users through the configuration of the router
-* monitoring of nodes through collectd
-* some well known network-interfaces
-  * "br-dhcp" for all client-traffic
-  * "wlan0-adhoc-2" and "wlan1-adhoc-5" for AdHoc-meshing between nodes in 2.4GHz and 5GHz
-  * "ffuplink" for all traffic sent via the uplink of the node-operator, in case "share traffic" is set up
-    * freifunk-policyrouting fixed/patched for ffuplink-interface
-* frei.funk as local DNS entry for your router
-  * you do not have to remember your IP to get access
-* change default lan ip address to 192.168.42.1/24
-  * avoids network collisions
-  * this is also used in OpenWrt failsafe
-* one dhcp network for APs and lan (bridged)
-* remove of autoipv6 and use of ULA ipv6 prefixes
-* default dns servers:
-  * 85.214.20.141 (FoeBud / Digital Courage)
-  * 80.67.169.40 (www.fdn.fr/actions/dns)
-  * 194.150.168.168 (dns.as250.net)
-  * 2001:4ce8::53 (as250)
-  * 2001:910:800::12 (french data network - http://www.fdn.fr/)
 
 ## Contact / More information
 
-The firmware wiki page is at: https://wiki.freifunk.net/Berlin:Firmware
+More user relevant information about the firmware are on the wiki page at: https://wiki.freifunk.net/Berlin:Firmware. There you can also find the 
+* [ReleaseNotes](https://wiki.freifunk.net/Berlin:Firmware/v1.0.2)
+* a tutorial ([en](https://wiki.freifunk.net/Berlin:Firmware:En:Howto) / [de](German: https://wiki.freifunk.net/Berlin:Firmware:Howto)) on router configuration 
 
 For questions write a mail to <berlin@berlin.freifunk.net> or come to our weekly meetings.
 If you find bugs please report them at: https://github.com/freifunk-berlin/firmware/issues
-
-A tutorial on router configuration is available here:
-German: https://wiki.freifunk.net/Berlin:Firmware:Howto
-English: https://wiki.freifunk.net/Berlin:Firmware:En:Howto
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ broken stuff in OpenWrt itself or for example LuCI) and additional default packa
 
 More user relevant information about the firmware are on the wiki page at: https://wiki.freifunk.net/Berlin:Firmware. There you can also find the 
 * [ReleaseNotes](https://wiki.freifunk.net/Berlin:Firmware/v1.0.2)
-* a tutorial ([en](https://wiki.freifunk.net/Berlin:Firmware:En:Howto) / [de](German: https://wiki.freifunk.net/Berlin:Firmware:Howto)) on router configuration 
+* a tutorial ([en](https://wiki.freifunk.net/Berlin:Firmware:En:Howto) / [de](https://wiki.freifunk.net/Berlin:Firmware:Howto)) on router configuration 
 
 For questions write a mail to <berlin@berlin.freifunk.net> or come to our weekly meetings.
 If you find bugs please report them at: https://github.com/freifunk-berlin/firmware/issues


### PR DESCRIPTION
As the Wiki is more up to date in this regard, just put a link in the Readme.
This also shortes the Readme a bit and helps to keep a focus on the relevant facts of the buils-system / firmware