### PR TITLE
config.mk: drop openvpn images

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 # default parameters for Makefile
 SHELL:=$(shell which bash)
 TARGET=ar71xx-generic
-PACKAGES_LIST_DEFAULT=default tunnel-berlin-openvpn tunnel-berlin-tunneldigger backbone
+PACKAGES_LIST_DEFAULT=default tunnel-berlin-tunneldigger backbone
 OPENWRT_SRC=https://git.openwrt.org/openwrt/openwrt.git
 OPENWRT_COMMIT=a02809f61bf9fda0387d37bd05d0bcfe8397e25d
 SET_BUILDBOT=env


### PR DESCRIPTION
The OpenVPN uplink  servers are no longer going to be supported.  This was
announced on the mailing list:

https://lists.berlin.freifunk.net/pipermail/berlin/2019-March/039247.html

Removing the OpenVPN images was requested on the freifunk-berlin mailing list:

https://lists.berlin.freifunk.net/pipermail/berlin/2019-March/039302.html