### PR TITLE
Openwrt 19.x - build: add the new luci-app-opkg to all image types

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -151,6 +151,7 @@ CONFIG_PACKAGE_luci-app-bmx6=m
 CONFIG_PACKAGE_luci-app-bmx7=m
 CONFIG_PACKAGE_luci-app-ffwizard-berlin=m
 CONFIG_PACKAGE_luci-app-firewall=m
+CONFIG_PACKAGE_luci-app-opkg=m
 CONFIG_PACKAGE_luci-app-olsr=m
 CONFIG_PACKAGE_luci-app-olsr-services=m
 CONFIG_PACKAGE_luci-app-olsr-viz=m

--- a/packages/backbone.txt
+++ b/packages/backbone.txt
@@ -34,6 +34,7 @@ libustream-mbedtls
 luci-mod-freifunk-ui
 luci-app-olsr
 luci-app-olsr-services
+luci-app-opkg
 luci-app-owm
 luci-app-owm-ant
 luci-app-owm-cmd

--- a/packages/backbone_4MB.txt
+++ b/packages/backbone_4MB.txt
@@ -42,6 +42,7 @@ luci-mod-freifunk-ui
 luci-mod-admin-full
 luci-app-olsr
 luci-app-olsr-services
+luci-app-opkg
 luci-app-owm
 luci-app-owm-cmd
 

--- a/packages/default.txt
+++ b/packages/default.txt
@@ -39,6 +39,7 @@ luci-mod-freifunk-ui
 luci-app-olsr
 luci-app-firewall
 luci-app-olsr-services
+luci-app-opkg
 luci-app-owm
 luci-app-owm-ant
 luci-app-owm-cmd

--- a/packages/tunnel-berlin-openvpn.txt
+++ b/packages/tunnel-berlin-openvpn.txt
@@ -39,6 +39,7 @@ luci-mod-freifunk-ui
 luci-app-olsr
 luci-app-firewall
 luci-app-olsr-services
+luci-app-opkg
 luci-app-owm
 luci-app-owm-ant
 luci-app-owm-cmd

--- a/packages/tunnel-berlin-tunneldigger.txt
+++ b/packages/tunnel-berlin-tunneldigger.txt
@@ -39,6 +39,7 @@ luci-mod-freifunk-ui
 luci-app-olsr
 luci-app-firewall
 luci-app-olsr-services
+luci-app-opkg
 luci-app-owm
 luci-app-owm-ant
 luci-app-owm-cmd


### PR DESCRIPTION
**Do not merge until the firmware is based on OpenWRT 19.x**

**https://github.com/freifunk-berlin/firmware-packages/pull/158 needs to be merged first**

The comment from the upstream commit is:
Add a new luci-app-opkg which is a feature-complete replacement for the
builtin opkg functionality of luci-mod-system using mostly client side
JavaScript to reduce the amount of server side processing.

luci-app-opkg is not added to the 4MB devices.  See https://github.com/freifunk-berlin/firmware/issues/626

The upstream commit in openwrt/luci is https://github.com/openwrt/luci/commit/aa2e0e2488f52b2b0acd1746ee13c7f51377f757

The freifunk-berlin issue is https://github.com/freifunk-berlin/firmware/issues/621