### PR TITLE
Add tunneldigger to the default and backbone images

### DIFF
--- a/packages/backbone.txt
+++ b/packages/backbone.txt
@@ -73,3 +73,6 @@ collectd-mod-rrdtool
 collectd-mod-ping
 collectd-mod-uptime
 collectd-mod-memory
+
+# Tunneldigger
+freifunk-berlin-tunneldigger

--- a/packages/default.txt
+++ b/packages/default.txt
@@ -83,3 +83,6 @@ collectd-mod-rrdtool
 collectd-mod-ping
 collectd-mod-uptime
 collectd-mod-memory
+
+# Tunneldigger
+freifunk-berlin-tunneldigger


### PR DESCRIPTION
This addresses issue #690 where a node which has been set up to
use the bbbdigger package cannot connect to the bbb-vpn server after
a firmware upgrade.

Additionally, this has been agreed upon at the firmware planning meeting 12.06.2019 https://pad.freifunk.net/p/berlin-2019