### PR TITLE
profiles: add device archer c7 v5

### DIFF
--- a/profiles/ar71xx-generic.profiles
+++ b/profiles/ar71xx-generic.profiles
@@ -1,6 +1,7 @@
 archer-c7-v1
 archer-c7-v2
 archer-c7-v4
+archer-c7-v5
 archer-c5-v1
 archer-c59-v1
 cpe210-v2


### PR DESCRIPTION
Add support for the Archer c7 V5 to 18.x based firmwares