### PR TITLE
packages: add mesh-flavor (OpenWrt Master)

### DIFF
--- a/packages/mesh_4MB.txt
+++ b/packages/mesh_4MB.txt
@@ -1,0 +1,42 @@
+-kmod-usb-core
+-kmod-usb2
+-kmod-usb-ledtrig-usbport
+-kmod-usb-ohci
+-kmod-ppp
+-kmod-usb-serial
+-ppp
+-ppp-mod-pppoe
+-wpad
+opkg
+-usign
+
+# Defaults
+freifunk-berlin-dhcp-defaults
+freifunk-berlin-freifunk-defaults
+freifunk-berlin-migration
+freifunk-berlin-network-defaults
+freifunk-berlin-olsrd-defaults
+freifunk-berlin-system-defaults
+community-profiles
+luci-app-owm-cmd
+
+# Common
+dnsmasq
+-firewall
+-iptables
+-ip6tables
+iwinfo
+libiwinfo-lua
+
+# OLSR
+olsrd
+#olsrd-mod-arprefresh
+olsrd-mod-dyn-gw
+olsrd-mod-jsoninfo
+olsrd-mod-nameservice
+olsrd-mod-watchdog
+kmod-ipip
+
+# BATMAN
+kmod-batman-adv
+batctl-tiny


### PR DESCRIPTION
This flavor provides a mesh-only node with full capabilities for 4MB devices.

This is the feature-list:
- console only
- includes B.A.T.M.A.N.
- no Uplink / VPN (no firewall)
- OLSRd with watchdog