### PR TITLE
Add Support for Netgear WNDR3700

### DIFF
--- a/patches/openwrt/0003-ramips-Netgear-WNDR3700v5-detect-board-name-from-DTS.patch
+++ b/patches/openwrt/0003-ramips-Netgear-WNDR3700v5-detect-board-name-from-DTS.patch
@@ -1,0 +1,143 @@
+From 71b8d4c1258a3b8e8d81ee061260fb9c61d46717 Mon Sep 17 00:00:00 2001
+From: Sven Roederer <devel-sven@geroedel.de>
+Date: Wed, 27 Nov 2019 22:55:27 +0100
+Subject: [PATCH] ramips: Netgear WNDR3700v5: detect board name from DTS
+
+- Former "wndr3700v5" board name becomes "netgear,wdnr3700-v5"
+- update LED-labels (based on commit da0de5e007cda0abef442bef860f867033206291)
+
+partial backport of: 2f2a319f82ec86e2008fd056987d74189d5c147b
+
+Signed-off-by: Sven Roederer <devel-sven@geroedel.de>
+---
+ .../linux/ramips/base-files/etc/board.d/01_leds  |  2 +-
+ .../ramips/base-files/etc/board.d/02_network     |  2 +-
+ .../base-files/etc/uci-defaults/04_led_migration | 16 ++++++++++++++++
+ target/linux/ramips/base-files/lib/ramips.sh     |  3 ---
+ target/linux/ramips/dts/WNDR3700V5.dts           | 10 +++++-----
+ target/linux/ramips/image/mt7621.mk              |  5 +++--
+ 6 files changed, 26 insertions(+), 12 deletions(-)
+ create mode 100644 target/linux/ramips/base-files/etc/uci-defaults/04_led_migration
+
+diff --git a/target/linux/ramips/base-files/etc/board.d/01_leds b/target/linux/ramips/base-files/etc/board.d/01_leds
+index 83cb88ad5c..245d98709e 100755
+--- a/target/linux/ramips/base-files/etc/board.d/01_leds
++++ b/target/linux/ramips/base-files/etc/board.d/01_leds
+@@ -281,7 +281,7 @@ px-4885-8M)
+ 	;;
+ r6220|\
+ netgear,r6350|\
+-wndr3700v5)
++netgear,wndr3700-v5)
+ 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
+ 	;;
+ re350-v1)
+diff --git a/target/linux/ramips/base-files/etc/board.d/02_network b/target/linux/ramips/base-files/etc/board.d/02_network
+index 0ffd5d6560..fb180a5e3e 100755
+--- a/target/linux/ramips/base-files/etc/board.d/02_network
++++ b/target/linux/ramips/base-files/etc/board.d/02_network
+@@ -175,7 +175,7 @@ ramips_setup_interfaces()
+ 	netgear,r6120|\
+ 	r6220|\
+ 	netgear,r6350|\
+-	wndr3700v5)
++	netgear,wndr3700-v5)
+ 		ucidef_add_switch "switch0" \
+ 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
+ 		;;
+diff --git a/target/linux/ramips/base-files/etc/uci-defaults/04_led_migration b/target/linux/ramips/base-files/etc/uci-defaults/04_led_migration
+new file mode 100644
+index 0000000000..e745c2c5d4
+--- /dev/null
++++ b/target/linux/ramips/base-files/etc/uci-defaults/04_led_migration
+@@ -0,0 +1,16 @@
++#!/bin/sh
++
++. /lib/functions.sh
++. /lib/functions/migrations.sh
++
++board=$(board_name)
++
++case "$board" in
++netgear,wndr3700-v5)
++	migrate_leds "^wndr3700v5:=wndr3700-v5:"
++	;;
++esac
++
++migrations_apply system
++
++exit 0
+diff --git a/target/linux/ramips/base-files/lib/ramips.sh b/target/linux/ramips/base-files/lib/ramips.sh
+index 093303892c..d9d66d3ebf 100755
+--- a/target/linux/ramips/base-files/lib/ramips.sh
++++ b/target/linux/ramips/base-files/lib/ramips.sh
+@@ -598,9 +598,6 @@ ramips_board_detect() {
+ 	*"WNCE2001")
+ 		name="wnce2001"
+ 		;;
+-	*"WNDR3700v5")
+-		name="wndr3700v5"
+-		;;
+ 	*"WR512-3GN (4M)")
+ 		name="wr512-3gn-4M"
+ 		;;
+diff --git a/target/linux/ramips/dts/WNDR3700V5.dts b/target/linux/ramips/dts/WNDR3700V5.dts
+index 475ddb7e95..ef6a209987 100644
+--- a/target/linux/ramips/dts/WNDR3700V5.dts
++++ b/target/linux/ramips/dts/WNDR3700V5.dts
+@@ -12,23 +12,23 @@
+ };
+ 
+ &led_power {
+-	label = "wndr3700v5:green:power";
++	label = "wndr3700-v5:green:power";
+ };
+ 
+ &led_usb {
+-	label = "wndr3700v5:green:usb";
++	label = "wndr3700-v5:green:usb";
+ };
+ 
+ &led_internet {
+-	label = "wndr3700v5:green:wan";
++	label = "wndr3700-v5:green:wan";
+ };
+ 
+ &led_wifi {
+-	label = "wndr3700v5:green:wifi";
++	label = "wndr3700-v5:green:wifi";
+ };
+ 
+ &led_wps {
+-	label = "wndr3700v5:green:wps";
++	label = "wndr3700-v5:green:wps";
+ };
+ 
+ &spi0 {
+diff --git a/target/linux/ramips/image/mt7621.mk b/target/linux/ramips/image/mt7621.mk
+index 7eb59188fb..9471356b26 100644
+--- a/target/linux/ramips/image/mt7621.mk
++++ b/target/linux/ramips/image/mt7621.mk
+@@ -561,7 +561,7 @@ define Device/mqmaker_witi-512m
+ endef
+ TARGET_DEVICES += mqmaker_witi-512m
+ 
+-define Device/wndr3700v5
++define Device/netgear_wndr3700-v5
+   DTS := WNDR3700V5
+   BLOCKSIZE := 64k
+   IMAGE_SIZE := 15232k
+@@ -576,8 +576,9 @@ define Device/wndr3700v5
+   DEVICE_TITLE := Netgear WNDR3700v5
+   DEVICE_PACKAGES := \
+ 	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
++  SUPPORTED_DEVICES += wndr3700v5
+ endef
+-TARGET_DEVICES += wndr3700v5
++TARGET_DEVICES += netgear_wndr3700-v5
+ 
+ define Device/youhua_wr1200js
+   DTS := WR1200JS
+-- 
+2.20.1
+

--- a/profiles/ath79-generic.profiles
+++ b/profiles/ath79-generic.profiles
@@ -1,6 +1,8 @@
 avm_fritz300e
 avm_fritz4020
 glinet_gl-ar300m-lite
+netgear_wndr3700
+netgear_wndr3700v2
 tplink_archer-c59-v1
 tplink_archer-c7-v4
 tplink_archer-c7-v5

--- a/profiles/ramips-mt7621.profiles
+++ b/profiles/ramips-mt7621.profiles
@@ -1,6 +1,6 @@
 ew1200
 mikrotik_rb750gr3
+netgear_wndr3700-v5
 ubnt-erx
 ubnt-erx-sfp
 xiaomi_mir3g
-wndr3700v5

--- a/profiles/ramips-mt7621.profiles
+++ b/profiles/ramips-mt7621.profiles
@@ -3,3 +3,4 @@ mikrotik_rb750gr3
 ubnt-erx
 ubnt-erx-sfp
 xiaomi_mir3g
+wndr3700v5


### PR DESCRIPTION
This will add support for the Netgear WDNR3700 v1,v2 and v5 as requested in Issue #736 .

This PR also includes a patch backporting the change of the V5-boardname from OpenWrt-master.