### PR TITLE
PATCHES.rst: adapt to new patches-structure

### DIFF
--- a/patches/PATCHES.rst
+++ b/patches/PATCHES.rst
@@ -1,16 +1,16 @@
 PATCHES
 #######
 
-Please add patches in the folowing structure
+Please add patches in the corresponding folder and use the folowing nameing-structure
 
 
-- 0xx - OpenWRT / LEDE related (upstream)
-- 1xx - packages (upstream)
-- 2xx - LUCI (upstream)
-- 3xx - routing (upstream)
-- 4xx - Freifunk (upstream)
-- 5xx - reserved
-- 6xx - build system changes to support this build system
-- 7xx - freifunk-berlin specific
-- 8xx - other
-- 9xx - reserved
+- 0xxx - Upstream fixes
+- 1xxx - Upstream backports
+- 2xxx - Upstream improvments
+- 3xxx - reserved
+- 4xxx - reserved
+- 5xxx - reserved
+- 6xxx - build system changes to support this build system
+- 7xxx - freifunk-berlin specific
+- 8xxx - other
+- 9xxx - reserved


### PR DESCRIPTION
Since we have switched to a per-repos based structure in 559cf96fffef70935effda414aa9da5210aa2a0c the current naming-scheme needs to be updated. As the subfolder already contains the repo, the affected repo don't need to be encoded in the patch-filename.

So I suggest the following scheme:
- 0xxx - Upstream fixes
- 1xxx - Upstream backports
- 2xxx - Upstream improvments
- 3xxx - reserved
- 4xxx - reserved
- 5xxx - reserved
- 6xxx - build system changes to support this build system
- 7xxx - freifunk-berlin specific
- 8xxx - other
- 9xxx - reserved