### PR TITLE
README.MD: Build Prerequisites: Arch/Antergos: Build dependency: python

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ zypper install git ncurses-devel zlib-devel gawk time \
 On Arch/Antergos:
 ```
 pacman -S base-devel git ncurses lib32-zlib gawk time unzip perl-xml-libxml \
- flex wget gettext quilt python openssl
+ flex wget gettext quilt python2 openssl
 ```
 
 ### Building all firmwares


### PR DESCRIPTION
Build dependency: Please install Python 2.x

`sudo pacman -S python` -> installs python3.x

`sudo pacman -S python2` -> installs python2.x