### PR TITLE
Fix version file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,24 +182,15 @@ initrd: .stamp-initrd
 	done
 	touch $@
 
+version-file: stamp-clean-$(VERSION_FILE) $(VERSION_FILE)
+
 $(VERSION_FILE): .stamp-prepared
 	mkdir -p $(FW_TARGET_DIR)
-	# Create version info file
-	GIT_BRANCH_ESC=$(shell $(GIT_BRANCH) | tr '/' '_'); \
-	echo "https://github.com/freifunk-berlin/firmware" > $(VERSION_FILE); \
-	echo "https://wiki.freifunk.net/Berlin:Firmware" >> $(VERSION_FILE); \
-	echo "Firmware: git branch \"$$GIT_BRANCH_ESC\", revision $(FW_REVISION)" >> $(VERSION_FILE); \
-	# add openwrt revision with data from config.mk \
-	OPENWRT_REVISION=`cd $(OPENWRT_DIR); $(REVISION)`; \
-	echo "OpenWRT: repository from $(OPENWRT_SRC), git branch \"$(OPENWRT_COMMIT)\", revision $$OPENWRT_REVISION" >> $(VERSION_FILE); \
-	# add feed revisions \
-	for FEED in `cd $(OPENWRT_DIR); ./scripts/feeds list -n`; do \
-	  FEED_DIR=$(addprefix $(OPENWRT_DIR)/feeds/,$$FEED); \
-	  FEED_GIT_REPO=`cd $$FEED_DIR; $(GIT_REPO)`; \
-	  FEED_GIT_BRANCH_ESC=`cd $$FEED_DIR; $(GIT_BRANCH) | tr '/' '_'`; \
-	  FEED_REVISION=`cd $$FEED_DIR; $(REVISION)`; \
-	  echo "Feed $$FEED: repository from $$FEED_GIT_REPO, git branch \"$$FEED_GIT_BRANCH_ESC\", revision $$FEED_REVISION" >> $(VERSION_FILE); \
-	done
+	VERSION_FILE=$(VERSION_FILE) \
+	  OPENWRT_DIR=$(OPENWRT_DIR) \
+	  REVISION_CMD="$(REVISION)" \
+	  GIT_BRANCH=$(shell $(GIT_BRANCH)) \
+	  ./scripts/create_version-txt.sh
 
 images: .stamp-images
 

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,9 @@ stamp-clean-firmwares:
 	rm -f $(OPENWRT_DIR)/.config
 	rm -f .stamp-$*
 
+stamp-clean-$(VERSION_FILE):
+	rm -f $(VERSION_FILE)
+
 stamp-clean-%:
 	rm -f .stamp-$*
 

--- a/scripts/create_version-txt.sh
+++ b/scripts/create_version-txt.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Create version info file in root folder of firmware-target
+#
+
+set -e
+
+. scripts/modules.sh
+
+GIT_BRANCH_ESC=$(echo ${GIT_BRANCH} | tr '/' '_')
+
+echo "https://github.com/freifunk-berlin/firmware" > ${VERSION_FILE}
+echo "https://wiki.freifunk.net/Berlin:Firmware" >> ${VERSION_FILE}
+echo "Firmware: git branch \"${GIT_BRANCH_ESC}\", revision $(${REVISION_CMD})" >> ${VERSION_FILE}
+# add openwrt revision with data from config.mk
+OPENWRT_REVISION=$(cd ${OPENWRT_DIR}; eval $REVISION_CMD base)
+echo "OpenWRT: repository from ${OPENWRT_REPO}, git branch \"${OPENWRT_BRANCH}\", revision ${OPENWRT_REVISION}" >> ${VERSION_FILE}
+# add feed revisions
+for FEED in `cd ${OPENWRT_DIR}; ./scripts/feeds list -n`; do \
+  FEED_DIR=${OPENWRT_DIR}/feeds/${FEED}
+  FEED_UCASE=$(echo ${FEED} | tr '[:lower:]' '[:upper:]')
+  FEED_GIT_REPO=$(echo PACKAGES_${FEED_UCASE}_REPO)
+  FEED_GIT_BRANCH=$(echo PACKAGES_${FEED_UCASE}_BRANCH)
+  FEED_REVISION=$(cd ${FEED_DIR}; ${REVISION_CMD} base)
+  echo "Feed $FEED: repository from ${!FEED_GIT_REPO}, git branch \"${!FEED_GIT_BRANCH}\", revision ${FEED_REVISION}" >> ${VERSION_FILE}
+done

--- a/scripts/create_version-txt.sh
+++ b/scripts/create_version-txt.sh
@@ -14,6 +14,7 @@ echo "https://wiki.freifunk.net/Berlin:Firmware" >> ${VERSION_FILE}
 echo "Firmware: git branch \"${GIT_BRANCH_ESC}\", revision $(${REVISION_CMD})" >> ${VERSION_FILE}
 # add openwrt revision with data from config.mk
 OPENWRT_REVISION=$(cd ${OPENWRT_DIR}; eval $REVISION_CMD base)
+[ -z ${OPENWRT_BRANCH} ] && OPENWRT_BRANCH=master
 echo "OpenWRT: repository from ${OPENWRT_REPO}, git branch \"${OPENWRT_BRANCH}\", revision ${OPENWRT_REVISION}" >> ${VERSION_FILE}
 # add feed revisions
 for FEED in `cd ${OPENWRT_DIR}; ./scripts/feeds list -n`; do \
@@ -22,5 +23,7 @@ for FEED in `cd ${OPENWRT_DIR}; ./scripts/feeds list -n`; do \
   FEED_GIT_REPO=$(echo PACKAGES_${FEED_UCASE}_REPO)
   FEED_GIT_BRANCH=$(echo PACKAGES_${FEED_UCASE}_BRANCH)
   FEED_REVISION=$(cd ${FEED_DIR}; ${REVISION_CMD} base)
-  echo "Feed $FEED: repository from ${!FEED_GIT_REPO}, git branch \"${!FEED_GIT_BRANCH}\", revision ${FEED_REVISION}" >> ${VERSION_FILE}
+  [ -z ${!FEED_GIT_BRANCH} ] && export ${FEED_GIT_BRANCH}=master
+  [ -z ${!FEED_GIT_REPO} ] || echo >> ${VERSION_FILE} \
+    "Feed $FEED: repository from ${!FEED_GIT_REPO}, git branch \"${!FEED_GIT_BRANCH}\", revision ${FEED_REVISION}"
 done


### PR DESCRIPTION
Since we apply the patches on the external repos, instead of just patching the upstream repo (e81f410) our VERSION.txt file shows this applied patch as commit of the repo. But the intention of the file is to show the original upstream commit we base on. So we need to use the "base" branch created by the patch.sh script.

broken VERSION.txt
```
https://github.com/freifunk-berlin/firmware
https://wiki.freifunk.net/Berlin:Firmware
Firmware: git branch "upstream-1907", revision 1307085
OpenWRT: repository from , git branch "", revision be248878cd
Feed packages: repository from , git branch "patched", revision 2e01dd838
Feed luci: repository from , git branch "patched", revision 79b792ba2
Feed freifunk: repository from , git branch "patched", revision 734d5a247
Feed routing: repository from , git branch "patched", revision 3f85711
Feed packages_berlin: repository from , git branch "patched", revision c3c0f4b
Feed packages_gluon: repository from , git branch "patched", revision 033401c
Feed telephony: repository from , git branch "patched", revision be248878cd
```

fixed VERSION.txt
```
https://github.com/freifunk-berlin/firmware
https://wiki.freifunk.net/Berlin:Firmware
Firmware: git branch "SAm0815-experimental_master", revision b7e888c
OpenWRT: repository from https://git.openwrt.org/openwrt/openwrt.git, git branch "openwrt-19.07", revision 5feb0df9bb
Feed packages: repository from https://github.com/openwrt/packages.git, git branch "openwrt-19.07", revision 72e4e36a3
Feed luci: repository from https://github.com/openwrt/luci.git, git branch "openwrt-19.07", revision 39a82906a
Feed freifunk: repository from https://github.com/freifunk/openwrt-packages.git, git branch "openwrt-19.07", revision 73454e6fe
Feed routing: repository from https://github.com/openwrt-routing/packages.git, git branch "openwrt-19.07", revision 9b42e24
Feed packages_berlin: repository from https://github.com/freifunk-berlin/firmware-packages.git, git branch "master", revision a96afe3
Feed packages_gluon: repository from https://github.com/freifunk-gluon/packages.git, git branch "master", revision 12e41d0
Feed packages_pdm: repository from https://github.com/Freifunk-Potsdam/firmware-packages.git, git branch "master", revision d379099
```