### PR TITLE
GHA/pr-conflict: add workflow to automatically find conflicting PRs

### DIFF
--- a/.github/workflows/pr-conflicts.yml
+++ b/.github/workflows/pr-conflicts.yml
@@ -1,0 +1,14 @@
+name: Check PRs for conflict
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "has conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds an GithubAction that checks if any open PR can not be merged on master
branch after a new commit was made to the master branch. If such conflict
will be detected, the affected PR will get the label "has conflicts". If
during a following run a conflicting PR becomes mergable, the flag will be
removed again.
This action is based on https://github.com/marketplace/actions/auto-label-merge-conflicts

This requires the correct label "has conflicts" needs to be created or the actions config must be adapted.