### PR TITLE
Misc fixes without functional change for enduser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .stamp*
 patches/*~
 bin
-^openwrt
+/openwrt
 firmwares
 dl
 /packages
+/tmp

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ http://github.com/freifunk-berlin/packages_berlin.
 ### Build Prerequisites
 
 Please take a look at the [OpenWrt documentation](https://openwrt.org/docs/guide-developer/build-system/install-buildsystem?s[]=prerequisites#prerequisites)
-for a complete and uptodate list of packages for your operating system. Make
-sure the list contains `quilt`. We use it for patch management.
+for a complete and uptodate list of packages for your operating system. 
 
 On Ubuntu/Debian:
 ```

--- a/profiles/ar71xx-generic.profiles
+++ b/profiles/ar71xx-generic.profiles
@@ -30,7 +30,6 @@ ubnt-air-gateway
 ubnt-air-gateway-pro
 ubnt-airrouter
 ubnt-bullet-m:tiny
-ubnt-ls-sr71
 ubnt-loco-m-xw:tiny
 ubnt-nano-m-xw:tiny
 ubnt-nano-m:tiny

--- a/profiles/ramips-mt7620.profiles
+++ b/profiles/ramips-mt7620.profiles
@@ -3,7 +3,6 @@ ArcherC50v1
 e1700
 gl-mt300a
 gl-mt300n
-mt7620a
 microwrt
 miwifi-mini
 tplink_c2-v1


### PR DESCRIPTION
This fixes should be just rebased onto.

The removed boards are evaluation-boards, so they will not be used by end-users anyway.