### PR TITLE
add support for TPlink CPE v2,v3 for ath79

### DIFF
--- a/profiles/ar71xx-generic.profiles
+++ b/profiles/ar71xx-generic.profiles
@@ -1,7 +1,6 @@
 archer-c7-v1
 archer-c7-v2
 archer-c5-v1
-cpe210-v2
 cpe210-220-v1
 cpe510-520-v1
 DIR505A1

--- a/profiles/ath79-generic.profiles
+++ b/profiles/ath79-generic.profiles
@@ -5,6 +5,7 @@ tplink_archer-c59-v1
 tplink_archer-c7-v4
 tplink_archer-c7-v5
 tplink_cpe210-v2
+tplink_cpe210-v3
 tplink_tl-wr1043n-v5
 ubnt_bullet-m-xw
 ubnt_nanostation-loco-m

--- a/profiles/ath79-generic.profiles
+++ b/profiles/ath79-generic.profiles
@@ -4,6 +4,7 @@ glinet_gl-ar300m-lite
 tplink_archer-c59-v1
 tplink_archer-c7-v4
 tplink_archer-c7-v5
+tplink_cpe210-v2
 tplink_tl-wr1043n-v5
 ubnt_bullet-m-xw
 ubnt_nanostation-loco-m


### PR DESCRIPTION
These boards are supported on ath79 since April 2019.  So I don't expect any problems hardware-wise.