### PR TITLE
don't use tiny-images for Ubiquiti XW boards

### DIFF
--- a/profiles/ar71xx-generic.profiles
+++ b/profiles/ar71xx-generic.profiles
@@ -29,11 +29,11 @@ ubnt-air-gateway
 ubnt-air-gateway-pro
 ubnt-airrouter
 ubnt-bullet-m:tiny
-ubnt-loco-m-xw:tiny
-ubnt-nano-m-xw:tiny
+ubnt-loco-m-xw
+ubnt-nano-m-xw
 ubnt-nano-m:tiny
 ubnt-rocket-m-ti:tiny
-ubnt-rocket-m-xw:tiny
+ubnt-rocket-m-xw
 ubnt-rocket-m:tiny
 ubnt-rs
 ubnt-rspro

--- a/profiles/ar71xx-generic.profiles
+++ b/profiles/ar71xx-generic.profiles
@@ -16,8 +16,8 @@ tl-wdr3500-v1
 tl-wdr3600-v1
 tl-wdr4300-v1
 tl-wdr4310-v1
-tl-wr710n-v1
-tl-wr710n-v2.1
+tl-wr710n-v1:tiny
+tl-wr710n-v2.1:tiny
 tl-wr842n-v1:tiny
 tl-wr842n-v2:tiny
 tl-wr842n-v3


### PR DESCRIPTION
The XW-boards are 8/64MB and should be able to run the regular packageflavor. The XM-boards are 8/32MB which makes them "tiny".
The TPLink WR710 boards are 8/32MB and should be treated as tiny.