### PR TITLE
Enable GithubActions to automatically build the firmware / Imagebuilder

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -25,30 +25,77 @@ jobs:
     - uses: actions/checkout@v2
     - name: install dependencies
       run: sudo apt-get --quiet --assume-yes --no-install-recommends --no-show-upgraded install git build-essential libncurses5-dev zlib1g-dev gawk time unzip libxml-perl flex wget gawk gettext quilt python libssl-dev
-    - name: setup folders
-      run: mkdir logs
-    - name: configure build
-      run: make -f Makefile.autobuild ${MAKE_OPTS} config
+    - name: setup build-environment
+      run: |
+        mkdir logs
+        echo "::set-env name=next_buildstep::config"
+    - name: OpenWrt ${{ env.next_buildstep }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-config)
+        echo "::set-env name=next_buildstep::${nextstep}"
     - name: OpenWrt-config to artifacts
       run: cp openwrt/.config logs/openwrt.config
-    - name: download openwrt packages
-      run: make -f Makefile.autobuild ${MAKE_OPTS} download
-    - name: build openwrt tools
-      run: make -f Makefile.autobuild ${MAKE_OPTS} tools
-    - name: build openwrt toolchain
-      run: make -f Makefile.autobuild ${MAKE_OPTS} toolchain
-    - name: build openwrt kmods
-      run: make -f Makefile.autobuild ${MAKE_OPTS} kmods
-    - name: build openwrt packages
-      run: make -f Makefile.autobuild ${MAKE_OPTS} packages
-    - name: build openwrt linux
-      run: make -f Makefile.autobuild ${MAKE_OPTS} linux
-    - name: build openwrt sdk
-      run: make -f Makefile.autobuild ${MAKE_OPTS} sdk
-    - name: build openwrt imagebuilder
-      run: make -f Makefile.autobuild ${MAKE_OPTS} imagebuilder
-    - name: build openwrt images
-      run: make -f Makefile.autobuild ${MAKE_OPTS} images
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
+    - name: openwrt ${{ env.next_buildstep }}
+      if: ${{ env.next_buildstep != null }}
+      run: |
+        make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
+        nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
+        echo "::set-env name=next_buildstep::${nextstep}"
     - name: Archive build logs
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -18,13 +18,14 @@ jobs:
 
     env:
       IS_BUILDBOT: yes
+      BUILD_LOG_DIR: logs
 
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
       run: sudo apt-get --quiet --assume-yes --no-install-recommends --no-show-upgraded install git build-essential libncurses5-dev zlib1g-dev gawk time unzip libxml-perl flex wget gawk gettext quilt python libssl-dev
     - name: setup folders
-      run: mkdir openwrt && ln -s ../logs openwrt/logs
+      run: mkdir logs
     - name: configure build
       run: make -f Makefile.autobuild TARGET=${{matrix.target}} config
     - name: download openwrt packages

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,0 +1,38 @@
+name: Build Firmware
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target: [ath79-generic, ramips-mt7620]
+
+    env:
+      IS_BUILDBOT: yes
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt-get --quiet --assume-yes --no-install-recommends --no-show-upgraded install git build-essential libncurses5-dev zlib1g-dev gawk time unzip libxml-perl flex wget gawk gettext quilt python libssl-dev
+    - name: configure build
+      run: make -f Makefile.autobuild TARGET=${{matrix.target}} config
+    - name: download openwrt packages
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} download
+    - name: build openwrt tools
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} tools
+    - name: build openwrt toolchain
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} toolchain
+    - name: build openwrt kmods
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} kmods
+    - name: build openwrt packages
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} packages
+    - name: build openwrt imagebuilder
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} imagebuilder

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -35,7 +35,11 @@ jobs:
       run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} kmods
     - name: build openwrt packages
       run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} packages
-    - name: build openwrt images
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} images
+    - name: build openwrt linux
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} linux
+    - name: build openwrt sdk
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} sdk
     - name: build openwrt imagebuilder
       run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} imagebuilder
+    - name: build openwrt images
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} images

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -26,6 +26,7 @@ jobs:
       run: sudo apt-get --quiet --assume-yes --no-install-recommends --no-show-upgraded install git build-essential libncurses5-dev zlib1g-dev gawk time unzip libxml-perl flex wget gawk gettext quilt python libssl-dev
     - name: setup build-environment
       run: |
+        df -h
         mkdir logs
         echo "::set-env name=MAKE_OPTS:: -j$(nproc) TARGET=${{matrix.target}} IS_BUILDBOT=${IS_BUILDBOT} "
         echo "::set-env name=next_buildstep::config"
@@ -34,6 +35,7 @@ jobs:
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-config)
         echo "::set-env name=next_buildstep::${nextstep}"
+        df -h
     - name: OpenWrt-config to artifacts
       run: cp openwrt/.config logs/openwrt.config
     - name: openwrt ${{ env.next_buildstep }}
@@ -121,3 +123,5 @@ jobs:
       with:
         name: ${{ matrix.target }}_bins
         path: openwrt/bin/
+    - run: df -h
+      if: ${{ !cancelled() }}

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -32,6 +32,7 @@ jobs:
         echo "::set-env name=next_buildstep::config"
     - name: OpenWrt ${{ env.next_buildstep }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-config)
         echo "::set-env name=next_buildstep::${nextstep}"
@@ -41,60 +42,70 @@ jobs:
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
+        echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
         echo "::set-env name=next_buildstep::${nextstep}"

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -53,6 +53,7 @@ jobs:
         path: logs
     - name: Archive binaries
       if: ${{ !cancelled() }}
+      continue-on-error: true
       uses: actions/upload-artifact@v1
       with:
         name: ${{ matrix.target }}_bins

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -18,6 +18,7 @@ jobs:
 
     env:
       IS_BUILDBOT: yes
+      MAKE_OPTS: -j$(nproc) TARGET=${{matrix.target}}
       BUILD_LOG_DIR: logs
 
     steps:
@@ -27,27 +28,27 @@ jobs:
     - name: setup folders
       run: mkdir logs
     - name: configure build
-      run: make -f Makefile.autobuild TARGET=${{matrix.target}} config
+      run: make -f Makefile.autobuild ${MAKE_OPTS} config
     - name: OpenWrt-config to artifacts
       run: cp openwrt/.config logs/openwrt.config
     - name: download openwrt packages
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} download
+      run: make -f Makefile.autobuild ${MAKE_OPTS} download
     - name: build openwrt tools
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} tools
+      run: make -f Makefile.autobuild ${MAKE_OPTS} tools
     - name: build openwrt toolchain
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} toolchain
+      run: make -f Makefile.autobuild ${MAKE_OPTS} toolchain
     - name: build openwrt kmods
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} kmods
+      run: make -f Makefile.autobuild ${MAKE_OPTS} kmods
     - name: build openwrt packages
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} packages
+      run: make -f Makefile.autobuild ${MAKE_OPTS} packages
     - name: build openwrt linux
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} linux
+      run: make -f Makefile.autobuild ${MAKE_OPTS} linux
     - name: build openwrt sdk
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} sdk
+      run: make -f Makefile.autobuild ${MAKE_OPTS} sdk
     - name: build openwrt imagebuilder
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} imagebuilder
+      run: make -f Makefile.autobuild ${MAKE_OPTS} imagebuilder
     - name: build openwrt images
-      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} images
+      run: make -f Makefile.autobuild ${MAKE_OPTS} images
     - name: Archive build logs
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         target: [ath79-generic, ramips-mt7620]
+      fail-fast: false
 
     env:
       IS_BUILDBOT: yes

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -18,7 +18,6 @@ jobs:
 
     env:
       IS_BUILDBOT: yes
-      MAKE_OPTS: -j$(nproc) TARGET=${{matrix.target}}
       BUILD_LOG_DIR: logs
 
     steps:
@@ -28,6 +27,7 @@ jobs:
     - name: setup build-environment
       run: |
         mkdir logs
+        echo "::set-env name=MAKE_OPTS:: -j$(nproc) TARGET=${{matrix.target}} IS_BUILDBOT=${IS_BUILDBOT} "
         echo "::set-env name=next_buildstep::config"
     - name: OpenWrt ${{ env.next_buildstep }}
       run: |

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -43,3 +43,9 @@ jobs:
       run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} imagebuilder
     - name: build openwrt images
       run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} images
+    - name: Archive build logs
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{matrix.target}}_logs
+        path: openwrt/logs

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -102,6 +102,18 @@ jobs:
       with:
         name: ${{matrix.target}}_logs
         path: logs
+    - name: prepare upload of imagebuilder and sdk
+      run: |
+       mkdir tmp_build-tools
+       find openwrt/bin -name *imagebuilder*.tar.xz -exec mv '{}' tmp_build-tools/ \;
+       find openwrt/bin -name *sdk*.tar.xz -exec mv '{}' tmp_build-tools/ \;
+    - name: Archive imagebuilder and sdk
+      if: ${{ !cancelled() }}
+      continue-on-error: true
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.target }}_build-tools
+        path: tmp_build-tools
     - name: Archive binaries
       if: ${{ !cancelled() }}
       continue-on-error: true

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -51,3 +51,9 @@ jobs:
       with:
         name: ${{matrix.target}}_logs
         path: logs
+    - name: Archive binaries
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.target }}_bins
+        path: openwrt/bin/

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -28,6 +28,8 @@ jobs:
       run: mkdir logs
     - name: configure build
       run: make -f Makefile.autobuild TARGET=${{matrix.target}} config
+    - name: OpenWrt-config to artifacts
+      run: cp openwrt/.config logs/openwrt.config
     - name: download openwrt packages
       run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} download
     - name: build openwrt tools

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -23,6 +23,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: install dependencies
       run: sudo apt-get --quiet --assume-yes --no-install-recommends --no-show-upgraded install git build-essential libncurses5-dev zlib1g-dev gawk time unzip libxml-perl flex wget gawk gettext quilt python libssl-dev
+    - name: setup folders
+      run: mkdir openwrt && ln -s ../logs openwrt/logs
     - name: configure build
       run: make -f Makefile.autobuild TARGET=${{matrix.target}} config
     - name: download openwrt packages
@@ -48,4 +50,4 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: ${{matrix.target}}_logs
-        path: openwrt/logs
+        path: logs

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -34,5 +34,7 @@ jobs:
       run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} kmods
     - name: build openwrt packages
       run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} packages
+    - name: build openwrt images
+      run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} images
     - name: build openwrt imagebuilder
       run: make -f Makefile.autobuild -j$(nproc) TARGET=${{matrix.target}} imagebuilder

--- a/Makefile.autobuild
+++ b/Makefile.autobuild
@@ -10,9 +10,10 @@ OPENWRT_DIR=$(FW_DIR)/openwrt
 FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 
 
-download: $(OPENWRT_DIR)/.config
+download: .autobuild_stamp-download .FORCE
+.autobuild_stamp-download: $(OPENWRT_DIR)/.config
 	$(MAKE) -C $(OPENWRT_DIR) download
-	touch .autobuild_stamp-$@
+	touch $@
 
 tools: .autobuild_stamp-download
 	$(MAKE) -C $(OPENWRT_DIR) tools/install
@@ -26,12 +27,13 @@ kmods:
 	$(MAKE) -C $(OPENWRT_DIR) target/compile
 	touch .autobuild_stamp-$@
 
-packages:
+packages: .autobuild_stamp-packages .FORCE
+.autobuild_stamp-packages:
 	$(MAKE) -C $(OPENWRT_DIR) package/compile
 	$(MAKE) -C $(OPENWRT_DIR) package/install
-	touch .autobuild_stamp-$@
+	touch $@
 
-images:
+images: .autobuild_stamp-packages
 	$(MAKE) -C $(OPENWRT_DIR) target/install
 	touch .autobuild_stamp-$@
 
@@ -77,6 +79,6 @@ $(OPENWRT_DIR)/.config: $(FW_DIR)/configs/common-autobuild.config
 	cat $(FW_DIR)/configs/common-autobuild.config >>$(FW_DIR)/configs/common.config
 	$(MAKE) prepare
 
-
+.PHONY: download packages
 .FORCE:
 .SUFFIXES:

--- a/Makefile.autobuild
+++ b/Makefile.autobuild
@@ -12,41 +12,41 @@ FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 
 download: .autobuild_stamp-download .FORCE
 .autobuild_stamp-download: $(OPENWRT_DIR)/.config
-	$(MAKE) -C $(OPENWRT_DIR) download
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs download
 	touch $@
 
 tools: .autobuild_stamp-download
-	$(MAKE) -C $(OPENWRT_DIR) tools/install
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs tools/install
 	touch .autobuild_stamp-$@
 
 toolchain: 
-	$(MAKE) -C $(OPENWRT_DIR) toolchain/install
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs toolchain/install
 	touch .autobuild_stamp-$@
 
 kmods: 
-	$(MAKE) -C $(OPENWRT_DIR) target/compile
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/compile
 	touch .autobuild_stamp-$@
 
 packages: .autobuild_stamp-packages .FORCE
 .autobuild_stamp-packages:
-	$(MAKE) -C $(OPENWRT_DIR) package/compile
-	$(MAKE) -C $(OPENWRT_DIR) package/install
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs package/compile
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs package/install
 	touch $@
 
 images: .autobuild_stamp-packages
-	$(MAKE) -C $(OPENWRT_DIR) target/install
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/install
 	touch .autobuild_stamp-$@
 
 linux:
-	$(MAKE) -C $(OPENWRT_DIR) target/linux/install
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/linux/install
 	touch .autobuild_stamp-$@
 
 imagebuilder:
-	$(MAKE) -C $(OPENWRT_DIR) target/imagebuilder/install
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/imagebuilder/install
 	touch .autobuild_stamp-$@
 
 sdk:
-	$(MAKE) -C $(OPENWRT_DIR) target/sdk/install
+	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/sdk/install
 	touch .autobuild_stamp-$@
 
 travis: $(OPENWRT_DIR)/.config

--- a/Makefile.autobuild
+++ b/Makefile.autobuild
@@ -31,6 +31,10 @@ packages:
 	$(MAKE) -C $(OPENWRT_DIR) package/install
 	touch .stamp-$@
 
+images:
+	$(MAKE) -C $(OPENWRT_DIR) target/install
+	touch .stamp-$@
+
 linux:
 	$(MAKE) -C $(OPENWRT_DIR) target/linux/install
 	touch .stamp-$@

--- a/Makefile.autobuild
+++ b/Makefile.autobuild
@@ -12,40 +12,40 @@ FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 
 download: $(OPENWRT_DIR)/.config
 	$(MAKE) -C $(OPENWRT_DIR) download
-	touch .stamp-$@
+	touch .autobuild_stamp-$@
 
-tools: .stamp-download
+tools: .autobuild_stamp-download
 	$(MAKE) -C $(OPENWRT_DIR) tools/install
-	touch .stamp-$@
+	touch .autobuild_stamp-$@
 
 toolchain: 
 	$(MAKE) -C $(OPENWRT_DIR) toolchain/install
-	touch .stamp-$@
+	touch .autobuild_stamp-$@
 
 kmods: 
 	$(MAKE) -C $(OPENWRT_DIR) target/compile
-	touch .stamp-$@
+	touch .autobuild_stamp-$@
 
 packages:
 	$(MAKE) -C $(OPENWRT_DIR) package/compile
 	$(MAKE) -C $(OPENWRT_DIR) package/install
-	touch .stamp-$@
+	touch .autobuild_stamp-$@
 
 images:
 	$(MAKE) -C $(OPENWRT_DIR) target/install
-	touch .stamp-$@
+	touch .autobuild_stamp-$@
 
 linux:
 	$(MAKE) -C $(OPENWRT_DIR) target/linux/install
-	touch .stamp-$@
+	touch .autobuild_stamp-$@
 
 imagebuilder:
 	$(MAKE) -C $(OPENWRT_DIR) target/imagebuilder/install
-	touch .stamp-$@
+	touch .autobuild_stamp-$@
 
 sdk:
 	$(MAKE) -C $(OPENWRT_DIR) target/sdk/install
-	touch .stamp-$@
+	touch .autobuild_stamp-$@
 
 travis: $(OPENWRT_DIR)/.config
 	travis_wait $(MAKE) -C $(OPENWRT_DIR) toolchain/install

--- a/Makefile.autobuild
+++ b/Makefile.autobuild
@@ -12,7 +12,15 @@ FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 # current_step:next_step ... last_step:
 BUILD_STEPS=config:download download:tools tools:toolchain toolchain:kmods kmods:packages packages:linux linux:images images:
 
-download: .autobuild_stamp-download .FORCE
+info:
+ifeq ($(IS_BUILDBOT),yes)
+	$(info IS_BUILDBOT is $(IS_BUILDBOT))
+	$(info This is a CI-build with options $(MAKEFLAGS))
+else
+	$(error This Makefile ist specialized to run on CI-builds. You might no want to use it for local builds.)
+endif
+
+download: info .autobuild_stamp-download .FORCE
 .autobuild_stamp-download: $(OPENWRT_DIR)/.config
 	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs download
 	touch $@
@@ -75,7 +83,7 @@ buildbot: $(OPENWRT_DIR)/.config
 	rm -rf $(FW_DIR)/dl
 	$(MAKE) IB_FILE=$(FW_TARGET_DIR)/*-imagebuilder-*.tar.xz images
 
-config: $(OPENWRT_DIR)/.config
+config: info $(OPENWRT_DIR)/.config
 $(OPENWRT_DIR)/.config: $(FW_DIR)/configs/common-autobuild.config
 	TARGET_CONFIG_AUTOBUILD=$(FW_DIR)/configs/common-autobuild.config
 	cat $(FW_DIR)/configs/common-autobuild.config >>$(FW_DIR)/configs/common.config
@@ -91,6 +99,6 @@ next-buildstep-for-%:
 	done; \
 	echo $$next_step
 
-.PHONY: download packages next-buildstep-for-%
+.PHONY: download packages info next-buildstep-for-%
 .FORCE:
 .SUFFIXES:

--- a/Makefile.autobuild
+++ b/Makefile.autobuild
@@ -10,7 +10,7 @@ OPENWRT_DIR=$(FW_DIR)/openwrt
 FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 
 # current_step:next_step ... last_step:
-BUILD_STEPS=config:download download:tools tools:toolchain toolchain:kmods kmods:packages packages:linux linux:sdk sdk:imagebuilder imagebuilder:images images:
+BUILD_STEPS=config:download download:tools tools:toolchain toolchain:kmods kmods:packages packages:linux linux:images images:
 
 download: .autobuild_stamp-download .FORCE
 .autobuild_stamp-download: $(OPENWRT_DIR)/.config

--- a/Makefile.autobuild
+++ b/Makefile.autobuild
@@ -1,0 +1,78 @@
+include config.mk
+
+# get main- and subtarget name from TARGET
+MAINTARGET=$(word 1, $(subst -, ,$(TARGET)))
+SUBTARGET=$(word 2, $(subst -, ,$(TARGET)))
+
+# set dir and file names
+FW_DIR=$(shell pwd)
+OPENWRT_DIR=$(FW_DIR)/openwrt
+FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
+
+
+download: $(OPENWRT_DIR)/.config
+	$(MAKE) -C $(OPENWRT_DIR) download
+	touch .stamp-$@
+
+tools: .stamp-download
+	$(MAKE) -C $(OPENWRT_DIR) tools/install
+	touch .stamp-$@
+
+toolchain: 
+	$(MAKE) -C $(OPENWRT_DIR) toolchain/install
+	touch .stamp-$@
+
+kmods: 
+	$(MAKE) -C $(OPENWRT_DIR) target/compile
+	touch .stamp-$@
+
+packages:
+	$(MAKE) -C $(OPENWRT_DIR) package/compile
+	$(MAKE) -C $(OPENWRT_DIR) package/install
+	touch .stamp-$@
+
+linux:
+	$(MAKE) -C $(OPENWRT_DIR) target/linux/install
+	touch .stamp-$@
+
+imagebuilder:
+	$(MAKE) -C $(OPENWRT_DIR) target/imagebuilder/install
+	touch .stamp-$@
+
+sdk:
+	$(MAKE) -C $(OPENWRT_DIR) target/sdk/install
+	touch .stamp-$@
+
+travis: $(OPENWRT_DIR)/.config
+	travis_wait $(MAKE) -C $(OPENWRT_DIR) toolchain/install
+
+buildbot: $(OPENWRT_DIR)/.config
+	$(MAKE) compile
+	$(MAKE) version-file
+	# copy imagebuilder, sdk and toolchain (if existing)
+	# remove old versions
+	rm -rf $(FW_TARGET_DIR)
+	[ -d $(FW_TARGET_DIR) ] || mkdir -p $(FW_TARGET_DIR)
+	for file in $(OPENWRT_DIR)/bin/targets/$(MAINTARGET)/$(SUBTARGET)/*{imagebuilder,sdk,toolchain}*.tar.xz; do \
+	  if [ -e $$file ]; then mv $$file $(FW_TARGET_DIR)/ ; fi \
+	done
+	# copy packages
+	PACKAGES_DIR="$(FW_TARGET_DIR)/packages"; \
+	rm -rf $$PACKAGES_DIR; \
+	mkdir -p $$PACKAGES_DIR/targets/$(MAINTARGET)/$(SUBTARGET)/packages; \
+	cp -a $(OPENWRT_DIR)/bin/targets/$(MAINTARGET)/$(SUBTARGET)/packages/* $$PACKAGES_DIR/targets/$(MAINTARGET)/$(SUBTARGET)/packages; \
+	# e.g. packages/packages/mips_34k the doublicated packages is correct! \
+	cp -a $(OPENWRT_DIR)/bin/packages $$PACKAGES_DIR/
+	rm -rf $(OPENWRT_DIR)
+	rm -rf $(FW_DIR)/dl
+	$(MAKE) IB_FILE=$(FW_TARGET_DIR)/*-imagebuilder-*.tar.xz images
+
+config: $(OPENWRT_DIR)/.config
+$(OPENWRT_DIR)/.config: $(FW_DIR)/configs/common-autobuild.config
+	TARGET_CONFIG_AUTOBUILD=$(FW_DIR)/configs/common-autobuild.config
+	cat $(FW_DIR)/configs/common-autobuild.config >>$(FW_DIR)/configs/common.config
+	$(MAKE) prepare
+
+
+.FORCE:
+.SUFFIXES:

--- a/Makefile.autobuild
+++ b/Makefile.autobuild
@@ -9,6 +9,8 @@ FW_DIR=$(shell pwd)
 OPENWRT_DIR=$(FW_DIR)/openwrt
 FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 
+# current_step:next_step ... last_step:
+BUILD_STEPS=config:download download:tools tools:toolchain toolchain:kmods kmods:packages packages:linux linux:sdk sdk:imagebuilder imagebuilder:images images:
 
 download: .autobuild_stamp-download .FORCE
 .autobuild_stamp-download: $(OPENWRT_DIR)/.config
@@ -79,6 +81,16 @@ $(OPENWRT_DIR)/.config: $(FW_DIR)/configs/common-autobuild.config
 	cat $(FW_DIR)/configs/common-autobuild.config >>$(FW_DIR)/configs/common.config
 	$(MAKE) prepare
 
-.PHONY: download packages
+next-buildstep-for-%:
+#	@echo this step: $*
+#	@echo all steps: $(BUILD_STEPS)
+	@for step in $(BUILD_STEPS); do \
+	  curr_step=$$(echo $$step | cut -d : -f 1); \
+	  next_step=$$(echo $$step | cut -d : -f 2); \
+	  [[ $$curr_step = $* ]] && break; \
+	done; \
+	echo $$next_step
+
+.PHONY: download packages next-buildstep-for-%
 .FORCE:
 .SUFFIXES:

--- a/config.mk
+++ b/config.mk
@@ -2,5 +2,4 @@
 SHELL:=$(shell which bash)
 TARGET=ar71xx-generic
 PACKAGES_LIST_DEFAULT=notunnel tunnel-berlin-tunneldigger manual
-SET_BUILDBOT=env
 MAKE_ARGS=

--- a/configs/common-autobuild.config
+++ b/configs/common-autobuild.config
@@ -1,3 +1,4 @@
 CONFIG_AUTOREMOVE=y
 CONFIG_BUILD_LOG=y
+CONFIG_SDK=y
 CONFIG_VERSION_REPO="http://buildbot.berlin.freifunk.net/buildbot/stable/%V/%T/packages"

--- a/configs/common-autobuild.config
+++ b/configs/common-autobuild.config
@@ -1,2 +1,3 @@
 CONFIG_AUTOREMOVE=y
+CONFIG_BUILD_LOG=y
 CONFIG_VERSION_REPO="http://buildbot.berlin.freifunk.net/buildbot/stable/%V/%T/packages"


### PR DESCRIPTION
Based on #804 I evaluated several CI-solutions (https://github.com/freifunk-berlin/firmware/wiki/Continuous-integration). Based on the lack of managing such a system ourself, I effectively tested TravisCI and GitHubActions. This is my suggestion to reenable CI, with the option of CD and probably CT (fingers crossed).

I use this Github-Workflow on my repo since some months without issues. This PR implements the idea of Pr #796 in order to reduce the regular Makefile and use a specific Makefile for CI (this infact includes / reuses parts of the regular Makefile). The workflow currently just creates the imagebuilder and keeps relevant artifacts on GitHub only, but can be extended to also provide the final images.

