### PR TITLE
Makefile: improve check for TARGET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,26 @@ FW_TARGET_DIR=$(FW_DIR)/firmwares/$(MAINTARGET)-$(SUBTARGET)
 VERSION_FILE=$(FW_TARGET_DIR)/VERSION.txt
 UMASK=umask 022
 
+define newline
+
+
+endef
+
+
+define listtargets
+$(error $(1) TARGET defined ! $(newline) \
+  $(addprefix $(newline) * ,$(VALID_TARGETS)) \
+  $(newline)Please specify one from the list above via 'TARGET' environment or in config.mk)
+endef
+
 # test for existing $TARGET-config or abort
+VALID_TARGETS=$(sort $(notdir $(basename $(wildcard $(FW_DIR)/profiles/*.profiles))))
+ifdef TARGET
 ifeq ($(wildcard $(FW_DIR)/configs/$(TARGET).config),)
-$(error config for $(TARGET) not defined)
+$(call listtargets,Invalid)
+endif
+else
+$(call listtargets,No)
 endif
 
 # if any of the following files have been changed: clean up openwrt dir

--- a/Makefile
+++ b/Makefile
@@ -41,18 +41,9 @@ default: firmwares
 
 test-target:
 # test for existing $TARGET-config or abort
-#	@#echo $$TARGET
-#	$(info print TARGET: "$(TARGET)")
-#	$(info test1)
-#ifndef $(TARGET)
-#	$(info case1)
-#	$(call listtargets,No)
-#endif
-#	$(info test2)
 ifeq ($(TARGET),)
 $(call listtargets,No)
 endif
-$(info ifeq-test)
 ifeq ($(wildcard $(FW_DIR)/configs/$(TARGET).config),)
 $(call listtargets,Invalid)
 endif

--- a/config.mk
+++ b/config.mk
@@ -1,5 +1,5 @@
 # default parameters for Makefile
 SHELL:=$(shell which bash)
-TARGET=ar71xx-generic
+#TARGET=ar71xx-generic
 PACKAGES_LIST_DEFAULT=notunnel tunnel-berlin-tunneldigger manual
 MAKE_ARGS=


### PR DESCRIPTION
Make defining a TARGET in config.mk optinonal, by testing for it. Improve the test by a more verbose message, which includes the valid choices.
This avoids problems for people forgetting to override the default on commandline.