### PR TITLE
GHA/build-fw: replace deprecated 'set-env' with Environment Files

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -38,14 +38,14 @@ jobs:
       run: |
         df -h
         mkdir logs
-        echo "::set-env name=MAKE_OPTS:: -j$(nproc) TARGET=${{matrix.target}} IS_BUILDBOT=${IS_BUILDBOT} "
-        echo "::set-env name=next_buildstep::config"
+        echo "MAKE_OPTS= -j$(nproc) TARGET=${{matrix.target}} IS_BUILDBOT=${IS_BUILDBOT} " >>$GITHUB_ENV
+        echo "next_buildstep=config" >>$GITHUB_ENV
     - name: OpenWrt ${{ env.next_buildstep }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-config)
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
         df -h
     - name: OpenWrt-config to artifacts
       run: cp openwrt/.config logs/openwrt.config
@@ -55,70 +55,70 @@ jobs:
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: openwrt ${{ env.next_buildstep }}
       if: ${{ env.next_buildstep != null }}
       run: |
         echo "running: make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}"
         make -f Makefile.autobuild ${MAKE_OPTS} ${next_buildstep}
         nextstep=$(make -f Makefile.autobuild next-buildstep-for-${next_buildstep})
-        echo "::set-env name=next_buildstep::${nextstep}"
+        echo "next_buildstep=${nextstep}" >>$GITHUB_ENV
     - name: Archive build logs
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
looking at github actions logs, there are (security vulnerability) warnings:

> The set-env command is deprecated and will be disabled soon. Please upgrade to using Environment Files.
> For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

according to kubernetes/minikube#9541 running the following command to fix it:

`find . -type f -name "*.yml" -print0 | xargs -0 sed -i -r 's/echo "::set-env name=(.*)::(.*)"/echo "\1=\2" >> $GITHUB_ENV/g'"` 

---

The warnings have become errors recently, so the build fails and the fix need to be implemented. Tested this in my personal repo before and it seems fine.