### PR TITLE
Readme: python3.5 is now required for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for a complete and uptodate list of packages for your operating system.
 On Ubuntu/Debian:
 ```
 apt-get install git build-essential libncurses5-dev zlib1g-dev gawk time \
-  unzip libxml-perl flex wget gawk gettext quilt python libssl-dev
+  unzip libxml-perl flex wget gawk gettext quilt python3 libssl-dev
 ```
 
 On openSUSE:


### PR DESCRIPTION
Upstream-commit: 19938c8de7a062626796f53a2805608c0dd4edbd
Update the debian install-command