### PR TITLE
add Feature "devicepackages"

### DIFF
--- a/configs/ath79-generic.config
+++ b/configs/ath79-generic.config
@@ -1,6 +1,7 @@
 CONFIG_TARGET_ath79=y
 CONFIG_TARGET_ath79_generic=y
 CONFIG_PACKAGE_ath10k-firmware-qca988x=m
+CONFIG_PACKAGE_ath10k-firmware-qca9887=m
 CONFIG_PACKAGE_ath10k-firmware-qca9888=m
 CONFIG_PACKAGE_ath10k-firmware-qca988x-ct=m
 CONFIG_PACKAGE_ath10k-firmware-qca9887-ct=m

--- a/configs/ath79-generic.config
+++ b/configs/ath79-generic.config
@@ -1,6 +1,7 @@
 CONFIG_TARGET_ath79=y
 CONFIG_TARGET_ath79_generic=y
 CONFIG_PACKAGE_ath10k-firmware-qca988x=m
+CONFIG_PACKAGE_ath10k-firmware-qca9888=m
 CONFIG_PACKAGE_ath10k-firmware-qca988x-ct=m
 CONFIG_PACKAGE_ath10k-firmware-qca9887-ct=m
 CONFIG_PACKAGE_ath10k-firmware-qca9888-ct=m

--- a/configs/ath79-nand.config
+++ b/configs/ath79-nand.config
@@ -1,4 +1,5 @@
 CONFIG_TARGET_ath79=y
 CONFIG_TARGET_ath79_nand=y
+CONFIG_PACKAGE_ath10k-firmware-qca9887=m
 CONFIG_PACKAGE_ath10k-firmware-qca9887-ct=m
 CONFIG_PACKAGE_block-mount=m

--- a/configs/ipq40xx-generic.config
+++ b/configs/ipq40xx-generic.config
@@ -1,2 +1,4 @@
 CONFIG_TARGET_ipq40xx=y
 CONFIG_TARGET_ipq40xx_generic=y
+CONFIG_PACKAGE_ath10k-firmware-qca9884=m
+CONFIG_PACKAGE_ath10k-firmware-qca9884-ct=m

--- a/configs/ramips-mt7621.config
+++ b/configs/ramips-mt7621.config
@@ -2,3 +2,4 @@ CONFIG_TARGET_ramips=y
 CONFIG_TARGET_ramips_mt7621=y
 CONFIG_TARGET_ROOTFS_INITRAMFS=y
 # CONFIG_PACKAGE_kmod-ath9k-htc is not set
+CONFIG_PACKAGE_block-mount=m

--- a/packagelists/profile-packages.txt
+++ b/packagelists/profile-packages.txt
@@ -48,5 +48,9 @@ ubnt_unifiac-mesh-pro;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k at
 yuncore_a770;-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
 yuncore_a782;-kmod-ath10k-ct -ath10k-firmware-qca9888-ct kmod-ath10k ath10k-firmware-qca9888
 
+# boards with mass-storage (SATA, SD-cards) will benefit from additional packages
+mikrotik_routerboard-750gr3:block-mount kmod-fs-f2fs kmod-sdhci-mt7620
+
 # boards with integrated DSL-port need additional hardware-support (see Issue #838)
 avm_fritz7360sl:luci-proto-ipv6 luci-proto-ppp ppp ppp-mod-pppoe
+

--- a/packagelists/profile-packages.txt
+++ b/packagelists/profile-packages.txt
@@ -1,0 +1,7 @@
+# this file lists a profile which should get special modules installed / removed 
+# this will usually apply only to hardware drivers
+# profiles not listed here, will get the 
+# * default packages based on OpenWrts device-specific choice
+# * the packagelist we a currently building for
+#
+# Format: <boardname>:[-]package [package ...]

--- a/packagelists/profile-packages.txt
+++ b/packagelists/profile-packages.txt
@@ -47,3 +47,6 @@ ubnt_unifiac-mesh;-kmod-ath10k-ct kmod-ath10k -ath10k-firmware-qca988x-ct ath10k
 ubnt_unifiac-mesh-pro;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 yuncore_a770;-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
 yuncore_a782;-kmod-ath10k-ct -ath10k-firmware-qca9888-ct kmod-ath10k ath10k-firmware-qca9888
+
+# boards with integrated DSL-port need additional hardware-support (see Issue #838)
+avm_fritz7360sl:luci-proto-ipv6 luci-proto-ppp ppp ppp-mod-pppoe

--- a/packagelists/profile-packages.txt
+++ b/packagelists/profile-packages.txt
@@ -5,3 +5,41 @@
 # * the packagelist we a currently building for
 #
 # Format: <boardname>:[-]package [package ...]
+
+# ath10k Wave1 chips (AP and 802.11s in parallel with Caldera Tech drivers - Issue #696)
+dlink_dir-859-a1;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+elecom_wrc-1750ghbk2-i;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+engenius_ecb1750;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+engenius_epg5000;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+engenius_ews511ap;-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
+glinet_gl-x750;-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
+iodata_wn-ac1167dgr;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+iodata_wn-ac1600dgr;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+iodata_wn-ac1600dgr2;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+nec_wg1200cr;-kmod-ath10k-ct -ath10k-firmware-qca9888-ct kmod-ath10k ath10k-firmware-qca9888
+nec_wg800hp;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
+ocedo_koala;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+openmesh_om5p-ac-v2;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+tplink_archer-a7-v5;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+tplink_archer-c2-v3;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
+tplink_archer-c25-v1;-kmod-ath10k-ct-smallbuffers kmod-ath10k -ath10k-firmware-qca9887-ct ath10k-firmware-qca9887
+tplink_archer-c5-v1;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+tplink_archer-c58-v1;-kmod-ath10k-ct-smallbuffers kmod-ath10k -ath10k-firmware-qca9888-ct ath10k-firmware-qca9888
+tplink_archer-c6-v2;-kmod-ath10k-ct kmod-ath10k -ath10k-firmware-qca9888-ct ath10k-firmware-qca9888
+tplink_archer-c60-v1;-kmod-ath10k-ct-smallbuffers kmod-ath10k -ath10k-firmware-qca9888-ct ath10k-firmware-qca9888
+tplink_archer-c60-v2;-kmod-ath10k-ct-smallbuffers kmod-ath10k -ath10k-firmware-qca9888-ct ath10k-firmware-qca9888
+tplink_archer-c60-v3;-kmod-ath10k-ct-smallbuffers kmod-ath10k -ath10k-firmware-qca9888-ct ath10k-firmware-qca9888
+tplink_archer-c7-v2;-kmod-ath10k-ct kmod-ath10k -ath10k-firmware-qca988x-ct ath10k-firmware-qca988x
+tplink_archer-c7-v5;-kmod-ath10k-ct kmod-ath10k -ath10k-firmware-qca988x-ct ath10k-firmware-qca988x
+tplink_archer-d50-v1;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+tplink_re350k-v1;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+tplink_re450-v2;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+ubnt_nanobeam-ac;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+ubnt_nanostation-ac;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+ubnt_nanostation-ac-loco;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+ubnt_unifiac-lr;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+ubnt_unifiac-lite;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+ubnt_unifiac-mesh;-kmod-ath10k-ct kmod-ath10k -ath10k-firmware-qca988x-ct ath10k-firmware-qca988x
+ubnt_unifiac-mesh-pro;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+yuncore_a770;-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
+yuncore_a782;-kmod-ath10k-ct -ath10k-firmware-qca9888-ct kmod-ath10k ath10k-firmware-qca9888

--- a/packagelists/profile-packages.txt
+++ b/packagelists/profile-packages.txt
@@ -12,8 +12,10 @@ elecom_wrc-1750ghbk2-i;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k a
 engenius_ecb1750;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 engenius_epg5000;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 engenius_ews511ap;-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
+glinet_gl-ar750:-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
 glinet_gl-ar750s-nor:-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
 glinet_gl-ar750s-nor-nand:-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
+glinet_gl-e750:-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
 glinet_gl-x750;-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
 iodata_wn-ac1167dgr;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 iodata_wn-ac1600dgr;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x

--- a/packagelists/profile-packages.txt
+++ b/packagelists/profile-packages.txt
@@ -12,10 +12,13 @@ elecom_wrc-1750ghbk2-i;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k a
 engenius_ecb1750;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 engenius_epg5000;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 engenius_ews511ap;-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
+glinet_gl-ar750s-nor:-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
+glinet_gl-ar750s-nor-nand:-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
 glinet_gl-x750;-kmod-ath10k-ct -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
 iodata_wn-ac1167dgr;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 iodata_wn-ac1600dgr;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 iodata_wn-ac1600dgr2;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+netgear_r7800:kmod-ath10k -kmod-ath10k-ct ath10k-firmware-qca9984 -ath10k-firmware-qca9984-ct
 nec_wg1200cr;-kmod-ath10k-ct -ath10k-firmware-qca9888-ct kmod-ath10k ath10k-firmware-qca9888
 nec_wg800hp;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca9887-ct kmod-ath10k ath10k-firmware-qca9887
 ocedo_koala;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x

--- a/packagelists/profile-packages.txt
+++ b/packagelists/profile-packages.txt
@@ -32,6 +32,7 @@ tplink_archer-c60-v3;-kmod-ath10k-ct-smallbuffers kmod-ath10k -ath10k-firmware-q
 tplink_archer-c7-v2;-kmod-ath10k-ct kmod-ath10k -ath10k-firmware-qca988x-ct ath10k-firmware-qca988x
 tplink_archer-c7-v5;-kmod-ath10k-ct kmod-ath10k -ath10k-firmware-qca988x-ct ath10k-firmware-qca988x
 tplink_archer-d50-v1;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
+tplink_eap225-outdoor-v1:-kmod-ath10k-ct kmod-ath10k -ath10k-firmware-qca9888-ct ath10k-firmware-qca9888
 tplink_re350k-v1;-kmod-ath10k-ct -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 tplink_re450-v2;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x
 ubnt_nanobeam-ac;-kmod-ath10k-ct-smallbuffers -ath10k-firmware-qca988x-ct kmod-ath10k ath10k-firmware-qca988x

--- a/scripts/assemble_firmware.sh
+++ b/scripts/assemble_firmware.sh
@@ -139,7 +139,12 @@ info "Extract image builder $IB_FILE"
 tar xf "$IB_FILE" --strip-components=1 -C "$TEMP_DIR"
 
 for profile in $PROFILES ; do
-	info "Building a profile for $profile"
+	info "Building an image for $profile"
+
+	if [ -e "${PKGLIST_DIR}/profile-packages.txt" ] ; then
+		model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d':' -s -f 2)"
+		info "we include these extra packages: $model_packages"
+	fi
 
 	# profiles can have a suffix. like 4mb devices get a smaller package list pro use case
 	# UBNT:4MB -> profile "UBNT" suffix "4MB"
@@ -168,6 +173,7 @@ for profile in $PROFILES ; do
 		info "Using package list $package_list"
 
 		packages=$(parse_pkg_list_file "${PKGLIST_DIR}/${package_list}.txt")
+		packages="${packages} ${model_packages}"
 
 		if [ -z "${packages}" ] ; then
 			info "skipping this usecase, as package list is empty"

--- a/scripts/assemble_firmware.sh
+++ b/scripts/assemble_firmware.sh
@@ -147,10 +147,10 @@ for profile in $PROFILES ; do
 	profile="$(echo $profile | cut -d':' -f 1)"
 
 	if [ -e "${PKGLIST_DIR}/profile-packages.txt" ] ; then
-		model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d':' -s -f 2)"
+		model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d':' -s -f 2 | tr -t '\n' ' ')"
 		# this is compatibility for WeimarNetz-stype definitons
 		if [ -z "${model_packages}" ]; then
-			model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d';' -s -f 2)"
+			model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d';' -s -f 2| tr -t '\n' ' ')"
 		fi
 		info "we include these extra packages: $model_packages"
 	fi

--- a/scripts/assemble_firmware.sh
+++ b/scripts/assemble_firmware.sh
@@ -141,6 +141,11 @@ tar xf "$IB_FILE" --strip-components=1 -C "$TEMP_DIR"
 for profile in $PROFILES ; do
 	info "Building an image for $profile"
 
+	# profiles can have a suffix. like 4mb devices get a smaller package list pro use case
+	# UBNT:4MB -> profile "UBNT" suffix "4MB"
+	suffix="$(echo $profile | cut -d':' -f 2)"
+	profile="$(echo $profile | cut -d':' -f 1)"
+
 	if [ -e "${PKGLIST_DIR}/profile-packages.txt" ] ; then
 		model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d':' -s -f 2)"
 		# this is compatibility for WeimarNetz-stype definitons
@@ -149,11 +154,6 @@ for profile in $PROFILES ; do
 		fi
 		info "we include these extra packages: $model_packages"
 	fi
-
-	# profiles can have a suffix. like 4mb devices get a smaller package list pro use case
-	# UBNT:4MB -> profile "UBNT" suffix "4MB"
-	suffix="$(echo $profile | cut -d':' -f 2)"
-	profile="$(echo $profile | cut -d':' -f 1)"
 
 	for usecase in $USECASES ; do
 		package_list=""

--- a/scripts/assemble_firmware.sh
+++ b/scripts/assemble_firmware.sh
@@ -147,10 +147,10 @@ for profile in $PROFILES ; do
 	profile="$(echo $profile | cut -d':' -f 1)"
 
 	if [ -e "${PKGLIST_DIR}/profile-packages.txt" ] ; then
-		model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d':' -s -f 2 | tr -t '\n' ' ')"
+		model_packages="$(grep ^$profile ${PKGLIST_DIR}/profile-packages.txt | cut -d':' -s -f 2 | tr -t '\n' ' ')"
 		# this is compatibility for WeimarNetz-stype definitons
 		if [ -z "${model_packages}" ]; then
-			model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d';' -s -f 2| tr -t '\n' ' ')"
+			model_packages="$(grep ^$profile ${PKGLIST_DIR}/profile-packages.txt | cut -d';' -s -f 2| tr -t '\n' ' ')"
 		fi
 		info "we include these extra packages: $model_packages"
 	fi

--- a/scripts/assemble_firmware.sh
+++ b/scripts/assemble_firmware.sh
@@ -143,6 +143,10 @@ for profile in $PROFILES ; do
 
 	if [ -e "${PKGLIST_DIR}/profile-packages.txt" ] ; then
 		model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d':' -s -f 2)"
+		# this is compatibility for WeimarNetz-stype definitons
+		if [ -z "${model_packages}" ]; then
+			model_packages="$(grep $profile ${PKGLIST_DIR}/profile-packages.txt | cut -d';' -s -f 2)"
+		fi
 		info "we include these extra packages: $model_packages"
 	fi
 


### PR DESCRIPTION
This extends the `assemble_firmware.sh` script in a way to parse a additional file `profile-packages.txt` which allows to specify packages that should be installed / removed on a per profile / board basis.
The code is based on the changes of @WeimarNetz with minor changes for our flavor of the `assemble_firmware.sh`. Initially it was intended to fix issue #696 around the ath10k-wave1 chips. 
Quickly it turns out that this might also fix issue #838 (additional drivers for boards with integrated xDSL-hardware) and also allows adding mass storage support (SATA, SD-Card) in default images.