### PR TITLE
improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ default: firmwares
 # compatibility to Gluon.buildsystem
 # * setup required makros and variables
 
+.SHELLFLAGS = -ec
+
 # check for spaces & resolve possibly relative paths
 define mkabspath
    ifneq (1,$(words [$($(1))]))
@@ -55,10 +57,11 @@ export GLUON_TMPDIR GLUON_PATCHESDIR
 # restore .patch files from all commits between 
 # patched-branch and base-branch
 update-patches: .stamp-pre-patch .FORCE
-	@GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/update-patches.sh
-	@GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/patch.sh
-	@git status $(GLUON_PATCHESDIR)
-	@echo "patches/ has been updated from the packages-repos. You probably need to rebuild."
+	@
+	GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/update-patches.sh
+	GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/patch.sh
+	git status $(GLUON_PATCHESDIR)
+	echo "patches/ has been updated from the packages-repos. You probably need to rebuild."
 
 ## Gluon - End
 
@@ -78,19 +81,22 @@ openwrt-clean-bin:
 # update feeds
 feeds-update: stamp-clean-feeds-updated .stamp-feeds-updated
 .stamp-feeds-updated: .stamp-patched
-	@$(UMASK); GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/feeds.sh
+	@
+	$(UMASK); GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/feeds.sh
 	touch $@
 
 # prepare patch
 pre-patch: stamp-clean-pre-patch .stamp-pre-patch
 .stamp-pre-patch: $(FW_DIR)/modules
-	@GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/update.sh
+	@
+	GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/update.sh
 	touch $@
 
 # patch openwrt and feeds working copy
 patch: stamp-clean-patched .stamp-patched
 .stamp-patched: .stamp-pre-patch $(wildcard $(GLUON_PATCHESDIR)/openwrt/*) $(wildcard $(GLUON_PATCHESDIR)/packages/*/*)
-	@$(UMASK); GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/patch.sh
+	@
+	$(UMASK); GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/patch.sh
 	touch $@
 
 .stamp-build_rev: .FORCE
@@ -143,15 +149,15 @@ firmwares: stamp-clean-firmwares .stamp-firmwares
 	# copy imagebuilder, sdk and toolchain (if existing)
 	# remove old versions
 	rm -f $(FW_TARGET_DIR)/*.tar.xz
-	for file in $(OPENWRT_DIR)/bin/targets/$(MAINTARGET)/$(SUBTARGET)/*{imagebuilder,sdk,toolchain}*.tar.xz; do \
-	  if [ -e $$file ]; then mv $$file $(FW_TARGET_DIR)/ ; fi \
+	for file in $(OPENWRT_DIR)/bin/targets/$(MAINTARGET)/$(SUBTARGET)/*{imagebuilder,sdk,toolchain}*.tar.xz; do
+	  if [ -e $$file ]; then mv $$file $(FW_TARGET_DIR)/ ; fi
 	done
 	# copy packages
-	PACKAGES_DIR="$(FW_TARGET_DIR)/packages"; \
-	rm -rf $$PACKAGES_DIR; \
-	mkdir -p $$PACKAGES_DIR/targets/$(MAINTARGET)/$(SUBTARGET)/packages; \
-	cp -a $(OPENWRT_DIR)/bin/targets/$(MAINTARGET)/$(SUBTARGET)/packages/* $$PACKAGES_DIR/targets/$(MAINTARGET)/$(SUBTARGET)/packages; \
-	# e.g. packages/packages/mips_34k the doublicated packages is correct! \
+	PACKAGES_DIR="$(FW_TARGET_DIR)/packages"
+	rm -rf $$PACKAGES_DIR
+	mkdir -p $$PACKAGES_DIR/targets/$(MAINTARGET)/$(SUBTARGET)/packages
+	cp -a $(OPENWRT_DIR)/bin/targets/$(MAINTARGET)/$(SUBTARGET)/packages/* $$PACKAGES_DIR/targets/$(MAINTARGET)/$(SUBTARGET)/packages
+	# e.g. packages/packages/mips_34k the doublicated packages is correct!
 	cp -a $(OPENWRT_DIR)/bin/packages $$PACKAGES_DIR/
 	touch $@
 
@@ -163,11 +169,11 @@ initrd: .stamp-initrd
 	# remove old versions
 	rm -f $(INITRD_DIR)/*
 	# copy initrd images (if existing)
-	for file in $(TARGET_BINDIR)/*-vmlinux-initramfs.elf; do \
-	  if [ -e $$file ]; then mv $$file $(INITRD_DIR)/ ; fi \
+	for file in $(TARGET_BINDIR)/*-vmlinux-initramfs.elf; do
+	  if [ -e $$file ]; then mv $$file $(INITRD_DIR)/ ; fi
 	done
-	for profile in `cat profiles/$(MAINTARGET)-$(SUBTARGET).profiles`; do \
-	  if [ -e $(TARGET_BINDIR)/*-$$profile-initramfs-kernel.bin ]; then mv $(TARGET_BINDIR)/*-$$profile-initramfs-kernel.bin $(INITRD_DIR)/ ; fi \
+	for profile in `cat profiles/$(MAINTARGET)-$(SUBTARGET).profiles`; do
+	  if [ -e $(TARGET_BINDIR)/*-$$profile-initramfs-kernel.bin ]; then mv $(TARGET_BINDIR)/*-$$profile-initramfs-kernel.bin $(INITRD_DIR)/ ; fi
 	done
 	touch $@
 
@@ -213,13 +219,13 @@ endif
 	touch $@
 
 setup-sdk: .stamp-patched
-	 @if [ -z "$(SDK_FILE)" ]; then \
-		echo Error: Please provide SDK-FILE by using "make SDK_FILE=<filename>"; \
-		exit 1; \
+	@if [ -z "$(SDK_FILE)" ]; then
+		echo Error: Please provide SDK-FILE by using "make SDK_FILE=<filename>"
+		exit 1
 	fi
-	@if [[ ! "$(SDK_FILE)" == *"$(MAINTARGET)-$(SUBTARGET)"* ]]; then \
-		echo Error: TARGET seems not to match SDK-Target; \
-		exit 1; \
+	@if [[ ! "$(SDK_FILE)" == *"$(MAINTARGET)-$(SUBTARGET)"* ]]; then
+		echo Error: TARGET seems not to match SDK-Target
+		exit 1
 	fi
 	$(eval SDK_DIR=$(FW_DIR)/sdk-$(MAINTARGET)-$(SUBTARGET))
 	mkdir $(SDK_DIR)
@@ -230,8 +236,8 @@ setup-sdk: .stamp-patched
 	echo "src-link base ../../openwrt/package" >> $(SDK_DIR)/feeds.conf.default
 #	# replace ../../ by ../ (for relative feeds-path)
 #	#sed -i -e "s/..\/..\//..\//" $(SDK_DIR)/feeds.conf.default
-	@$(SDK_DIR)/scripts/feeds update
-	@$(UMASK); $(SDK_DIR)/scripts/feeds install -a
+	$(SDK_DIR)/scripts/feeds update
+	$(UMASK); $(SDK_DIR)/scripts/feeds install -a
 	cat $(TARGET_CONFIG) >$(SDK_DIR)/.config
 	$(UMASK); $(MAKE) -C $(SDK_DIR) defconfig
 
@@ -255,3 +261,4 @@ clean: stamp-clean .stamp-openwrt-cleaned
 .NOTPARALLEL:
 .FORCE:
 .SUFFIXES:
+.ONESHELL:

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ update-patches: .stamp-pre-patch .FORCE
 # clean up openwrt working copy
 openwrt-clean: stamp-clean-openwrt-cleaned .stamp-openwrt-cleaned
 .stamp-openwrt-cleaned: config.mk | $(OPENWRT_DIR) openwrt-clean-bin
+	+
 	cd $(OPENWRT_DIR); \
 	  ./scripts/feeds clean && \
 	  git clean -dff && git fetch && git reset --hard HEAD && \
@@ -81,7 +82,7 @@ openwrt-clean-bin:
 # update feeds
 feeds-update: stamp-clean-feeds-updated .stamp-feeds-updated
 .stamp-feeds-updated: .stamp-patched
-	@
+	@+
 	$(UMASK); GLUON_SITEDIR='$(GLUON_SITEDIR)' scripts/feeds.sh
 	touch $@
 
@@ -122,6 +123,7 @@ $(OPENWRT_DIR)/files: $(FW_DIR)/embedded-files
 
 # openwrt config
 $(OPENWRT_DIR)/.config: .stamp-feeds-updated $(TARGET_CONFIG) .stamp-build_rev $(OPENWRT_DIR)/dl
+	+
 	cat $(TARGET_CONFIG) >$(OPENWRT_DIR)/.config
 	# always replace CONFIG_VERSION_CODE by FW_REVISION
 	sed -i "/^CONFIG_VERSION_CODE=/c\CONFIG_VERSION_CODE=\"$(FW_REVISION)\"" $(OPENWRT_DIR)/.config
@@ -136,6 +138,7 @@ prepare: stamp-clean-prepared .stamp-prepared
 # compile
 compile: stamp-clean-compiled .stamp-compiled
 .stamp-compiled: .stamp-prepared openwrt-clean-bin
+	+
 	$(UMASK); \
 	  $(MAKE) -C $(OPENWRT_DIR) $(MAKE_ARGS)
 	touch $@
@@ -200,9 +203,11 @@ images: .stamp-images
 #                  prerequirement is a build OpenWRT
 ifeq ($(origin IB_FILE),command line)
 .stamp-images: $(FW_DIR)/embedded-files .FORCE
+	+
 	$(info IB_FILE explicitly defined; using it for building firmware-images)
 else
 .stamp-images: .stamp-compiled
+	+
 	$(info IB_FILE not defined; assuming called from inside regular build)
 	$(eval IB_FILE := $(shell ls -tr $(OPENWRT_DIR)/bin/targets/$(MAINTARGET)/$(SUBTARGET)/*-imagebuilder-*.tar.xz | tail -n1))
 endif
@@ -219,6 +224,7 @@ endif
 	touch $@
 
 setup-sdk: .stamp-patched
+	+
 	@if [ -z "$(SDK_FILE)" ]; then
 		echo Error: Please provide SDK-FILE by using "make SDK_FILE=<filename>"
 		exit 1

--- a/Makefile.autobuild
+++ b/Makefile.autobuild
@@ -22,49 +22,49 @@ endif
 
 download: info .autobuild_stamp-download .FORCE
 .autobuild_stamp-download: $(OPENWRT_DIR)/.config
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs download
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs download
 	touch $@
 
 tools: .autobuild_stamp-download
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs tools/install
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs tools/install
 	touch .autobuild_stamp-$@
 
 toolchain: 
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs toolchain/install
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs toolchain/install
 	touch .autobuild_stamp-$@
 
 kmods: 
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/compile
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/compile
 	touch .autobuild_stamp-$@
 
 packages: .autobuild_stamp-packages .FORCE
 .autobuild_stamp-packages:
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs package/compile
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs package/install
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs package/compile
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs package/install
 	touch $@
 
 images: .autobuild_stamp-packages
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/install
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/install
 	touch .autobuild_stamp-$@
 
 linux:
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/linux/install
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/linux/install
 	touch .autobuild_stamp-$@
 
 imagebuilder:
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/imagebuilder/install
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/imagebuilder/install
 	touch .autobuild_stamp-$@
 
 sdk:
-	$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/sdk/install
+	+$(MAKE) -C $(OPENWRT_DIR) BUILD_LOG_DIR=$(FW_DIR)/logs target/sdk/install
 	touch .autobuild_stamp-$@
 
 travis: $(OPENWRT_DIR)/.config
-	travis_wait $(MAKE) -C $(OPENWRT_DIR) toolchain/install
+	+travis_wait $(MAKE) -C $(OPENWRT_DIR) toolchain/install
 
 buildbot: $(OPENWRT_DIR)/.config
-	$(MAKE) compile
-	$(MAKE) version-file
+	+$(MAKE) compile
+	+$(MAKE) version-file
 	# copy imagebuilder, sdk and toolchain (if existing)
 	# remove old versions
 	rm -rf $(FW_TARGET_DIR)
@@ -81,13 +81,13 @@ buildbot: $(OPENWRT_DIR)/.config
 	cp -a $(OPENWRT_DIR)/bin/packages $$PACKAGES_DIR/
 	rm -rf $(OPENWRT_DIR)
 	rm -rf $(FW_DIR)/dl
-	$(MAKE) IB_FILE=$(FW_TARGET_DIR)/*-imagebuilder-*.tar.xz images
+	+$(MAKE) IB_FILE=$(FW_TARGET_DIR)/*-imagebuilder-*.tar.xz images
 
 config: info $(OPENWRT_DIR)/.config
 $(OPENWRT_DIR)/.config: $(FW_DIR)/configs/common-autobuild.config
 	TARGET_CONFIG_AUTOBUILD=$(FW_DIR)/configs/common-autobuild.config
 	cat $(FW_DIR)/configs/common-autobuild.config >>$(FW_DIR)/configs/common.config
-	$(MAKE) prepare
+	+$(MAKE) prepare
 
 next-buildstep-for-%:
 #	@echo this step: $*


### PR DESCRIPTION
This is a collection of changes which are not related to each other.

* using .ONESHELL and adding -e to .SHELLFLAGS, simplifies complex shell commands. (cherry-picked from https://github.com/freifunk-gluon/gluon/commit/a180bb8689ed5d02229108c77bb66bf098f68364)
* fix #596 - not passing make jobcontrol flags to sub-makes